### PR TITLE
fix: patch for UE default content wrapper

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -443,7 +443,7 @@ function decorateSections(main) {
         wrappers[wrappers.length - 1].append(e);
       }
     });
-    
+
     wrappers.forEach((wrapper) => section.append(wrapper));
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -429,21 +429,15 @@ function decorateSections(main) {
   main.querySelectorAll(':scope > div').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;
-
     [...section.children].forEach((e) => {
-      if (e.classList.contains('default-content-wrapper')) {
-        wrappers.push(e);
-      } else if (e.tagName === 'DIV' || !defaultContent) {
+      if (e.tagName === 'DIV' || !defaultContent) {
         const wrapper = document.createElement('div');
         wrappers.push(wrapper);
         defaultContent = e.tagName !== 'DIV';
         if (defaultContent) wrapper.classList.add('default-content-wrapper');
-        wrapper.append(e);
-      } else {
-        wrappers[wrappers.length - 1].append(e);
       }
+      wrappers[wrappers.length - 1].append(e);
     });
-
     wrappers.forEach((wrapper) => section.append(wrapper));
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -429,15 +429,21 @@ function decorateSections(main) {
   main.querySelectorAll(':scope > div').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;
+
     [...section.children].forEach((e) => {
-      if (e.tagName === 'DIV' || !defaultContent) {
+      if (e.classList.contains('default-content-wrapper')) {
+        wrappers.push(e);
+      } else if (e.tagName === 'DIV' || !defaultContent) {
         const wrapper = document.createElement('div');
         wrappers.push(wrapper);
         defaultContent = e.tagName !== 'DIV';
         if (defaultContent) wrapper.classList.add('default-content-wrapper');
+        wrapper.append(e);
+      } else {
+        wrappers[wrappers.length - 1].append(e);
       }
-      wrappers[wrappers.length - 1].append(e);
     });
+    
     wrappers.forEach((wrapper) => section.append(wrapper));
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -4,7 +4,6 @@ import {
   loadFooter,
   decorateButtons,
   decorateIcons,
-  decorateSections,
   decorateBlocks,
   decorateTemplateAndTheme,
   getMetadata,
@@ -13,6 +12,9 @@ import {
   loadSections,
   loadCSS,
   sampleRUM,
+  readBlockConfig,
+  toClassName,
+  toCamelCase,
 } from './aem.js';
 
 /**
@@ -64,6 +66,61 @@ function buildAutoBlocks(main) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);
   }
+}
+
+/**
+ * Decorates all sections in a container element.
+ * @param {Element} main The container element
+ */
+function decorateSections(main) {
+  main.querySelectorAll(':scope > div').forEach((section) => {
+    const wrappers = [];
+    let defaultContent = false;
+
+    [...section.children].forEach((e) => {
+      if (e.classList.contains('richtext')) {
+        e.className = 'default-content-wrapper';
+        wrappers.push(e);
+      } else if (e.getAttribute('data-aue-type') === 'media') {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('default-content-wrapper');
+        wrappers.push(wrapper);
+        wrapper.append(e);
+      } else if (e.tagName === 'DIV' || !defaultContent) {
+        const wrapper = document.createElement('div');
+        wrappers.push(wrapper);
+        defaultContent = e.tagName !== 'DIV';
+        if (defaultContent) wrapper.classList.add('default-content-wrapper');
+        wrapper.append(e);
+      } else {
+        wrappers[wrappers.length - 1].append(e);
+      }
+    });
+
+    // Add wrapped content back
+    wrappers.forEach((wrapper) => section.append(wrapper));
+    section.classList.add('section');
+    section.dataset.sectionStatus = 'initialized';
+    section.style.display = 'none';
+
+    // Process section metadata
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      Object.keys(meta).forEach((key) => {
+        if (key === 'style') {
+          const styles = meta.style
+            .split(',')
+            .filter((style) => style)
+            .map((style) => toClassName(style.trim()));
+          styles.forEach((style) => section.classList.add(style));
+        } else {
+          section.dataset[toCamelCase(key)] = meta[key];
+        }
+      });
+      sectionMeta.parentNode.remove();
+    }
+  });
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -81,7 +81,7 @@ function decorateSections(main) {
         e.removeAttribute('class');
         if (!defaultContent) {
           const wrapper = document.createElement('div');
-          wrapper.classList.add('default-content-wrapper')
+          wrapper.classList.add('default-content-wrapper');
           wrappers.push(wrapper);
           defaultContent = true;
         }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -76,25 +76,22 @@ function decorateSections(main) {
   main.querySelectorAll(':scope > div').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;
-
     [...section.children].forEach((e) => {
       if (e.classList.contains('richtext')) {
-        e.className = 'default-content-wrapper';
-        wrappers.push(e);
-      } else if (e.getAttribute('data-aue-type') === 'media') {
-        const wrapper = document.createElement('div');
-        wrapper.classList.add('default-content-wrapper');
-        wrappers.push(wrapper);
-        wrapper.append(e);
+        e.removeAttribute('class');
+        if (!defaultContent) {
+          const wrapper = document.createElement('div');
+          wrapper.classList.add('default-content-wrapper')
+          wrappers.push(wrapper);
+          defaultContent = true;
+        }
       } else if (e.tagName === 'DIV' || !defaultContent) {
         const wrapper = document.createElement('div');
         wrappers.push(wrapper);
         defaultContent = e.tagName !== 'DIV';
         if (defaultContent) wrapper.classList.add('default-content-wrapper');
-        wrapper.append(e);
-      } else {
-        wrappers[wrappers.length - 1].append(e);
       }
+      wrappers[wrappers.length - 1].append(e);
     });
 
     // Add wrapped content back


### PR DESCRIPTION
See https://experience.adobe.com/#/@sitesinternal/aem/editor/canvas/ue-default-content--da-block-collection--aemsites.stage-ue.da.live/demo ... should look and behave like normal especially for the default content.

Test URLs:
- Before: https://main--da-block-collection--aemsites.aem.page/demo
- After: https://ue-default-content--da-block-collection--aemsites.aem.page/demo