### PR TITLE
Polish row drag-and-drop reordering in MEP manifest tool

### DIFF
--- a/docs/superpowers/plans/2026-07-23-row-reorder-polish.md
+++ b/docs/superpowers/plans/2026-07-23-row-reorder-polish.md
@@ -1,0 +1,363 @@
+# Row Reorder Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the MEP manifest tool's existing row drag-and-drop reordering discoverable and precise — a visible grip handle, an unambiguous before/after insertion indicator, and reliable cleanup — with no changes to the data model or DA save flow.
+
+**Architecture:** Pure UI polish inside the existing native HTML5 drag-and-drop implementation in the Experiences grid. No new dependencies, no schema changes: row order is already array position and already persists correctly through `model.toSheet()` / `saveManifest()`.
+
+**Tech Stack:** Vanilla JS (ES modules), plain CSS with custom properties. No framework, no drag library.
+
+## Global Constraints
+
+- No new npm dependencies — stay vanilla JS / CSS, matching the rest of `tools/mep-manifest`.
+- Only these files change: `tools/mep-manifest/src/ui/experiences-tab.js`, `tools/mep-manifest/mep-manifest.css`.
+- No changes to `tools/mep-manifest/src/data/manifest-model.js` (`moveRow` is already correct), `da-sheet-adapter.js`, or the save/preview/publish flow in `app.js`.
+- Out of scope, do not build: keyboard-based reordering (up/down buttons), touch/mobile drag support.
+- This tool has no automated test runner (`package.json` has no `test` script and no jsdom/jest/vitest devDependency). Verification is manual, in-browser, via `aem up` — this matches the project's existing convention for this tool (see `docs/superpowers/specs/2026-07-23-row-reorder-polish-design.md`, "Testing" section). Do not introduce a new test framework as part of this change.
+
+---
+
+### Task 1: Visible drag handle + CSS-driven dragging state
+
+**Files:**
+- Modify: `tools/mep-manifest/src/ui/experiences-tab.js:145-169` (the "Row number / drag handle" block inside the `model.experiences.rows.forEach` loop in `render()`)
+- Modify: `tools/mep-manifest/mep-manifest.css:380-394` (the "Row handle" section)
+
+**Interfaces:**
+- Consumes: `model.moveRow(fromIdx, toIdx)` (unchanged, from `manifest-model.js:125-129`), `render()` (the local closure in `experiences-tab.js:98`), `rowIdx`/`row`/`tr` (loop-scoped variables already in place).
+- Produces: a `.drag-handle` div (with child `.drag-handle-grip` span and a row-number span) inside the existing `.col-handle` `<td>`. A `row-dragging` class toggled on the `<tr>` during drag, replacing the old inline `tr.style.opacity` toggle. Task 2 builds directly on this markup and on the `row-dragging` class name.
+
+This task keeps today's drop behavior unchanged (dropping still always inserts *before* the hovered row) — it only makes the handle visible and moves the dragging-row style from inline JS styles to a CSS class. Task 2 adds the before/after insertion-line logic on top of this.
+
+- [ ] **Step 1: Replace the row-handle markup and drag styling in `experiences-tab.js`**
+
+Find this block at `experiences-tab.js:145-169`:
+
+```js
+      // Row number / drag handle
+      const handleTd = document.createElement('td');
+      handleTd.className = 'col-handle';
+      handleTd.textContent = rowIdx + 1;
+      handleTd.draggable = true;
+      handleTd.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('text/plain', rowIdx);
+        tr.style.opacity = '0.4';
+      });
+      handleTd.addEventListener('dragend', () => { tr.style.opacity = '1'; });
+      tr.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '2px solid var(--mep-primary)';
+      });
+      tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });
+      tr.addEventListener('drop', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '';
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        if (fromIdx !== rowIdx) {
+          model.moveRow(fromIdx, rowIdx);
+          render();
+        }
+      });
+      tr.append(handleTd);
+```
+
+Replace it with:
+
+```js
+      // Row number / drag handle
+      const handleTd = document.createElement('td');
+      handleTd.className = 'col-handle';
+
+      const handle = document.createElement('div');
+      handle.className = 'drag-handle';
+      handle.draggable = true;
+      handle.title = 'Drag to reorder';
+
+      const grip = document.createElement('span');
+      grip.className = 'drag-handle-grip';
+      grip.textContent = '⠿';
+      grip.setAttribute('aria-hidden', 'true');
+
+      const rowNum = document.createElement('span');
+      rowNum.textContent = rowIdx + 1;
+
+      handle.append(grip, rowNum);
+      handleTd.append(handle);
+
+      handle.addEventListener('dragstart', (e) => {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(rowIdx));
+        tr.classList.add('row-dragging');
+      });
+      handle.addEventListener('dragend', () => { tr.classList.remove('row-dragging'); });
+      tr.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        tr.style.borderTop = '2px solid var(--mep-primary)';
+      });
+      tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });
+      tr.addEventListener('drop', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '';
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        if (fromIdx !== rowIdx) {
+          model.moveRow(fromIdx, rowIdx);
+          render();
+        }
+      });
+      tr.append(handleTd);
+```
+
+- [ ] **Step 2: Update the "Row handle" CSS section**
+
+Find this block at `mep-manifest.css:380-394`:
+
+```css
+/* Row handle */
+.mep-grid td.col-handle {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  text-align: center;
+  color: var(--mep-text-secondary);
+  cursor: grab;
+  font-size: 12px;
+  vertical-align: middle;
+}
+
+.mep-grid td.col-handle:hover {
+  background: #f0f0f0;
+}
+```
+
+Replace it with:
+
+```css
+/* Row handle */
+.mep-grid td.col-handle {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  padding: 0;
+  vertical-align: middle;
+}
+
+.mep-grid .drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 100%;
+  height: 100%;
+  min-height: 36px;
+  color: var(--mep-text-secondary);
+  font-size: 12px;
+  cursor: grab;
+  user-select: none;
+}
+
+.mep-grid .drag-handle:hover {
+  background: #f0f0f0;
+}
+
+.mep-grid .drag-handle-grip {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.mep-grid tr.row-dragging {
+  opacity: 0.4;
+}
+
+.mep-grid tr.row-dragging .drag-handle {
+  cursor: grabbing;
+}
+```
+
+- [ ] **Step 3: Lint**
+
+Run:
+```bash
+cd tools/mep-manifest && npx eslint src/ui/experiences-tab.js && npx stylelint ../../mep-manifest.css
+```
+Expected: no errors (the repo's root `npm run lint:js` / `npm run lint:css` also cover this file — either works; use whichever runs faster from your shell).
+
+- [ ] **Step 4: Manual browser check**
+
+Run `aem up` from the repo root, then open `http://localhost:3000/tools/mep-manifest/mep-manifest.html` in a browser. In the file browser header, click the **NEW** pill, enter any name (e.g. `test-reorder`), click **Create**. In the Experiences grid, click **+ Add Row** four times so there are 4 rows.
+
+Confirm:
+- Each row's leftmost cell shows a grip icon (⠿) next to the row number, with `cursor: grab` on hover.
+- Dragging a row by its handle dims it to ~40% opacity while dragging, and a blue line appears at the top of whatever row is under the cursor.
+- Releasing the drop still reorders the rows (behavior unchanged from before this task — only the visuals changed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mep-manifest/src/ui/experiences-tab.js tools/mep-manifest/mep-manifest.css
+git commit -m "feat: add visible grip handle for row drag-and-drop"
+```
+
+---
+
+### Task 2: Before/after insertion-line indicator with corrected drop math
+
+**Files:**
+- Modify: `tools/mep-manifest/src/ui/experiences-tab.js` (the `tbody` setup just above the row loop, and the drag event listeners inside the row loop that Task 1 left in place)
+- Modify: `tools/mep-manifest/mep-manifest.css` (append new rules after the block Task 1 added)
+
+**Interfaces:**
+- Consumes: `handle`, `handleTd`, `tr`, `rowIdx`, `tbody` (all already in scope from Task 1 / the surrounding `render()` closure), `model.moveRow(fromIdx, toIdx)`.
+- Produces: a `clearDragIndicators()` helper function (module-private, defined once per `render()` call) that Task 3's manual test relies on indirectly (it's what makes the indicator behave correctly, not something a later task calls directly).
+
+This task replaces the "always insert before the hovered row" behavior with an explicit above/below check based on cursor position, and fixes the index math so the drop lands exactly where the indicator shows.
+
+- [ ] **Step 1: Add the `clearDragIndicators` helper**
+
+Find this in `experiences-tab.js` (added once, right after `const tbody = document.createElement('tbody');` inside `render()`):
+
+```js
+    // Body
+    const tbody = document.createElement('tbody');
+```
+
+Replace it with:
+
+```js
+    // Body
+    const tbody = document.createElement('tbody');
+
+    function clearDragIndicators() {
+      tbody.querySelectorAll('tr').forEach((row) => {
+        row.classList.remove('drag-insert-before', 'drag-insert-after');
+      });
+    }
+```
+
+- [ ] **Step 2: Replace the dragover/dragleave/drop/dragend handlers with before/after logic**
+
+Find this block (as left by Task 1) inside the row loop:
+
+```js
+      handle.addEventListener('dragstart', (e) => {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(rowIdx));
+        tr.classList.add('row-dragging');
+      });
+      handle.addEventListener('dragend', () => { tr.classList.remove('row-dragging'); });
+      tr.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        tr.style.borderTop = '2px solid var(--mep-primary)';
+      });
+      tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });
+      tr.addEventListener('drop', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '';
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        if (fromIdx !== rowIdx) {
+          model.moveRow(fromIdx, rowIdx);
+          render();
+        }
+      });
+```
+
+Replace it with:
+
+```js
+      handle.addEventListener('dragstart', (e) => {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(rowIdx));
+        tr.classList.add('row-dragging');
+      });
+
+      handle.addEventListener('dragend', () => {
+        tr.classList.remove('row-dragging');
+        clearDragIndicators();
+      });
+
+      tr.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+
+        const rect = tr.getBoundingClientRect();
+        const isBottomHalf = (e.clientY - rect.top) > rect.height / 2;
+
+        clearDragIndicators();
+        tr.classList.add(isBottomHalf ? 'drag-insert-after' : 'drag-insert-before');
+      });
+
+      tr.addEventListener('dragleave', (e) => {
+        if (!tr.contains(e.relatedTarget)) {
+          tr.classList.remove('drag-insert-before', 'drag-insert-after');
+        }
+      });
+
+      tr.addEventListener('drop', (e) => {
+        e.preventDefault();
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        const isAfter = tr.classList.contains('drag-insert-after');
+        clearDragIndicators();
+
+        if (Number.isNaN(fromIdx) || fromIdx === rowIdx) return;
+
+        let toIdx = isAfter ? rowIdx + 1 : rowIdx;
+        // moveRow splices the row out first, which shifts every index
+        // after it down by one — compensate when dragging downward.
+        if (fromIdx < toIdx) toIdx -= 1;
+
+        model.moveRow(fromIdx, toIdx);
+        render();
+      });
+```
+
+- [ ] **Step 3: Add the insertion-line CSS**
+
+Append this after the block Task 1 added in `mep-manifest.css` (i.e., right after the `.mep-grid tr.row-dragging .drag-handle { cursor: grabbing; }` rule):
+
+```css
+/* Drag insertion-line indicator */
+.mep-grid tr.drag-insert-before td {
+  box-shadow: inset 0 2px 0 0 var(--mep-primary);
+}
+
+.mep-grid tr.drag-insert-after td {
+  box-shadow: inset 0 -2px 0 0 var(--mep-primary);
+}
+```
+
+- [ ] **Step 4: Lint**
+
+Run:
+```bash
+cd tools/mep-manifest && npx eslint src/ui/experiences-tab.js && npx stylelint ../../mep-manifest.css
+```
+Expected: no errors.
+
+- [ ] **Step 5: Manual browser check — verify the index math**
+
+Using the same local setup as Task 1 (`aem up`, open the tool, create a test manifest, add 4 rows). Before testing, type a distinct value into the Selector cell of each row (e.g. `row-1`, `row-2`, `row-3`, `row-4`) so you can track identity by content, not just position.
+
+Confirm each of these:
+1. Hover the cursor over the **top half** of a row while dragging another row over it → the blue line appears **above** that row. Drop → the dragged row ends up directly above it.
+2. Hover over the **bottom half** of a row → the line appears **below** it. Drop → the dragged row ends up directly below it.
+3. Drag `row-1` and drop it in the bottom half of `row-4` (the last row) → final order is `row-2, row-3, row-4, row-1`.
+4. Drag `row-4` and drop it in the top half of `row-1` (the first row) → final order is `row-4, row-1, row-2, row-3`.
+5. Start dragging a row, then release the mouse button outside the table entirely (e.g. over the toolbar) → no blue line or dimmed row is left behind; the grid returns to normal.
+6. Click **Save** after a reorder (if you have DA credentials configured for this to succeed) or at minimum confirm no console errors are thrown — order persistence itself goes through the unchanged `model.toSheet()` / `saveManifest()` path and isn't otherwise re-tested here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/mep-manifest/src/ui/experiences-tab.js tools/mep-manifest/mep-manifest.css
+git commit -m "feat: add before/after insertion indicator to row drag-and-drop"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 covers spec section "1. Visible handle." Task 2 covers spec sections "2. Insertion-line indicator" and "3. Drag state styling" (dimmed dragged row is Task 1; hover/insertion-line + full cleanup on dragend/dragleave is Task 2). Both tasks together cover "4. Files touched." The spec's "Testing" bullets map directly to Task 1 Step 4 and Task 2 Step 5.
+- **Placeholder scan:** No TBDs; every step has complete, runnable code and exact commands.
+- **Type/name consistency:** `clearDragIndicators` (Task 2 Step 1) is the exact name used in Task 2 Step 2's handlers. `row-dragging`, `drag-insert-before`, `drag-insert-after`, `drag-handle`, `drag-handle-grip` are the same class strings across the JS and CSS steps in both tasks.

--- a/docs/superpowers/specs/2026-07-23-row-reorder-polish-design.md
+++ b/docs/superpowers/specs/2026-07-23-row-reorder-polish-design.md
@@ -1,0 +1,65 @@
+# Row Reorder Polish — Design
+
+## Problem
+
+The Experiences grid in the MEP manifest tool already has row reordering wired up: the row-number cell (`.col-handle`) is `draggable`, and `dragstart`/`dragover`/`drop` handlers on the `<tr>` call `model.moveRow(fromIdx, toIdx)`, which correctly splices the row array. Row order is pure array position — it already round-trips through `model.toSheet()` and the DA save/upload flow with no schema changes needed.
+
+The problem is discoverability and feedback, not data flow:
+
+- The "handle" is a bare row number (`1`, `2`, `3`, …) with `cursor: grab` on hover — nothing signals it's draggable.
+- The only feedback during a drag is a 2px top border on the row currently under the cursor, which doesn't distinguish "drop above this row" from "drop below this row."
+- No visible cue on the row actually being dragged beyond a partial opacity fade.
+
+Net effect: users don't discover the capability, and when they do use it, it's hard to tell exactly where a row will land before releasing.
+
+## Scope
+
+In scope:
+- Visible drag handle (grip icon + row number) in `tools/mep-manifest/src/ui/experiences-tab.js`.
+- Clear insertion-line feedback showing whether a drop will land above or below the hovered row, based on cursor position within that row.
+- Cleaned-up drag-ghost/highlight styling, with reset on `dragend`/`drop`/`dragleave`, audited for edge cases (e.g. dragging out of the table entirely).
+- Supporting CSS in `tools/mep-manifest/mep-manifest.css`.
+
+Out of scope (explicitly deferred, not built as part of this change):
+- Keyboard-based reordering (e.g. up/down buttons).
+- Touch/mobile drag support (native HTML5 DnD doesn't support touch).
+- Any change to the data model, `moveRow()`, `toSheet()`, or the DA save/upload path — order is already correctly array-position-based and already persists correctly.
+
+## Design
+
+### 1. Visible handle
+
+Replace the handle `<td>` content (currently just `rowIdx + 1` as text) with a small flex row containing:
+- A grip glyph (⠿) as the drag affordance.
+- The row number, kept for reference.
+
+CSS: keep `cursor: grab` on the handle, add `cursor: grabbing` while a drag is in progress (toggled via a class on the handle or row during `dragstart`/`dragend`).
+
+### 2. Insertion-line indicator
+
+Replace the current "top border on hovered row" approach with an explicit indicator element (a thin absolutely-positioned line) that:
+- Appears above the hovered row if the cursor's Y position is in the top half of that row's bounding box.
+- Appears below the hovered row if the cursor's Y position is in the bottom half.
+
+Implementation: in the `dragover` handler (currently on `tr`), compute cursor position relative to the row's `getBoundingClientRect()`, and toggle two CSS classes (`drag-insert-before` / `drag-insert-after`) on the row accordingly — driving a `::before`/`::after` pseudo-element or a bordered edge — instead of always setting `borderTop`.
+
+The existing `fromIdx`/`toIdx` computation on `drop` needs a small adjustment: if the insertion point is "after" the hovered row, the target index shifts by one relative to today's behavior (which always inserts at `rowIdx`, i.e., always "before"). This is the one behavioral change beyond pure styling — it makes drop position match what the indicator shows.
+
+### 3. Drag state styling
+
+- Dragged row: keep dimmed opacity (already present), ensure it's restored on `dragend` even if the drop target was invalid or outside the grid.
+- Hovered valid drop target: no full-row highlight beyond the insertion line, to keep the signal specific (avoids "which row is highlighted vs. where exactly will it land" ambiguity).
+- Reset all transient classes/styles (`dragging`, `drag-insert-before`, `drag-insert-after`, inline `borderTop` if left over from the old approach) on `dragend`, `drop`, and `dragleave` of the table body as a whole, not just per-row, so a drag that ends outside the grid doesn't leave stale styling.
+
+### 4. Files touched
+
+- `tools/mep-manifest/src/ui/experiences-tab.js` — handle markup, dragover/drop logic, index-adjustment for before/after.
+- `tools/mep-manifest/mep-manifest.css` — grip icon styling, `cursor: grabbing`, insertion-line classes, dragging-row opacity class (replacing inline `tr.style.opacity`/`tr.style.borderTop` with CSS classes where practical).
+
+## Testing
+
+Manual verification in the browser (this tool has no existing test suite for the UI layer):
+- Drag a row up/down within a multi-row grid; confirm the insertion line shows above/below correctly as the cursor moves within a row.
+- Drop above the first row and below the last row; confirm both work.
+- Start a drag and release outside the table; confirm no stale highlight/opacity remains.
+- Confirm the resulting row order matches what's shown after drop, and that Save persists the new order to DA (existing `toSheet()`/`saveManifest()` path — no changes expected here, but worth a smoke check).

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,4 +1,4 @@
 mountpoints:
   /:
-    url: https://content.da.live/aemsites/da-block-collection/
+    url: https://content.da.live/sharg1/da-block-collection/
     type: markup

--- a/tools/mep-manifest/DUE-DILIGENCE.md
+++ b/tools/mep-manifest/DUE-DILIGENCE.md
@@ -1,0 +1,238 @@
+# MEP Manifest Manager — Architecture Due Diligence
+
+> **Status:** Draft for Architect Review
+> **Date:** 2026-04-01
+
+---
+
+## Table of Contents
+
+1. [Overview & Goals](#overview--goals)
+2. [System Context](#system-context)
+3. [Architecture Approach](#architecture-approach)
+4. [Implementation Details](#implementation-details)
+5. [UI Approach](#ui-approach)
+6. [Risks & Open Questions](#risks--open-questions)
+
+---
+
+## Overview & Goals
+
+The **MEP Manifest Manager** is a purpose-built editor embedded inside the Document Authoring (DA) shell. It allows content authors to create, edit, preview, and publish **MEP (Manifest Experience Personalization)** files — the structured configuration that drives personalization, A/B testing, and promotional experiences on AEM Edge Delivery sites.
+
+**Problem it solves:** Without this tool, authors must manually edit raw spreadsheet rows in DA to define personalization rules. This is error-prone, provides no visual feedback, and requires knowledge of the MEP schema. The tool replaces that with a structured, form-driven UI that abstracts the underlying data format entirely.
+
+**Key user journeys:**
+- Browse the DA repository and open an existing manifest
+- Create a new manifest from scratch and define its type and metadata
+- Build experience rules — mapping CSS selectors to content actions across named audience segments
+- Define reusable placeholder key/value pairs
+- Save, preview, and publish the manifest to AEM Live
+
+---
+
+## System Context
+
+The tool runs as a **DA plugin** — loaded inside the DA shell as an iframe. It communicates with the DA shell via the DA SDK (postMessage bridge), which provides the authenticated user's organization context and bearer token. All manifest files are stored in and retrieved from the **DA Admin API**.
+
+```
+┌──────────────────────────────────────────────────┐
+│                  DA Shell (da.live)               │
+│                                                  │
+│   ┌──────────────────────────────────────────┐   │
+│   │       MEP Manifest Manager (iframe)      │   │
+│   │                                          │   │
+│   │  File Browser → Grid Editor → Toolbar   │   │
+│   └────────────────┬─────────────────────────┘   │
+│                    │ DA SDK (postMessage)         │
+└────────────────────┼─────────────────────────────┘
+                     │
+          ┌──────────▼──────────┐
+          │   DA Admin API      │
+          │  (admin.da.live)    │
+          │  List / Read / Write│
+          │  Preview / Publish  │
+          └─────────────────────┘
+                     │
+          ┌──────────▼──────────┐
+          │  AEM Edge Delivery  │
+          │  (aem.page/.live)   │
+          │  Consumes manifests │
+          └─────────────────────┘
+```
+
+**Actors:**
+- **Content Author** — Uses the tool to manage personalization manifests
+- **DA Shell** — Hosts the iframe, provides auth context via the DA SDK
+- **DA Admin API** — Stores manifest files and handles preview/publish operations
+- **AEM Edge Delivery** — Reads published manifests at runtime to drive personalization
+
+---
+
+## Architecture Approach
+
+### Single-Page Application, No Framework
+
+The tool is a lightweight SPA built in **vanilla JavaScript (ES6 modules)** with no third-party UI framework and no build step required. This is consistent with the broader AEM Edge Delivery philosophy of zero-dependency, framework-free tooling. The benefit is a minimal footprint that loads instantly inside the DA iframe with no compilation overhead.
+
+### Layered, Modular Design
+
+The application is organized into three clear layers with strict boundaries between them:
+
+```
+┌────────────────────────────────────┐
+│         UI Layer                   │
+│  Renders views, handles DOM events │
+└────────────────┬───────────────────┘
+                 │ calls
+┌────────────────▼───────────────────┐
+│      Orchestration Layer           │
+│  Manages state transitions,        │
+│  wires UI to data, handles actions │
+└────────────────┬───────────────────┘
+                 │ calls
+┌────────────────▼───────────────────┐
+│         Data Layer                 │
+│  Model, DA API adapter, serializer │
+└────────────────────────────────────┘
+```
+
+- The **Data Layer** has no knowledge of the DOM or the UI.
+- The **UI Layer** has no knowledge of the DA API.
+- The **Orchestration Layer** (app) is the only place that connects the two.
+
+### Reactive Model
+
+A central `ManifestModel` object holds all application state. Every mutation (edit, add, remove, reorder) marks the model as "dirty" and notifies registered listeners. UI elements subscribe to these change events — for example, the toolbar reflects unsaved changes, and the status bar toggles between "Saved" and "Unsaved changes" automatically.
+
+### Dual-Mode Bootstrap
+
+The tool is designed to operate in two contexts:
+1. **Inside DA shell (production):** The DA SDK resolves with the real org context and bearer token.
+2. **Standalone on localhost (development):** If the SDK is unavailable, the app falls back to a mock context so developers can run and test the tool locally without needing the full DA environment.
+
+This is implemented via a race condition at startup — the SDK call races against a short timeout. If the SDK wins, the real context is used. If the timeout wins, the mock context takes over.
+
+---
+
+## Implementation Details
+
+### Manifest Lifecycle
+
+Every manifest moves through the same lifecycle:
+
+```
+Open / New → Edit → Save → Preview → Publish
+```
+
+| Stage | Description |
+|-------|-------------|
+| **Open** | Author picks a JSON file from the file browser. The raw DA sheet data is fetched and parsed into the internal model. |
+| **New** | A blank model is created with one default experience column and one empty row, giving authors a starting point. |
+| **Edit** | Author modifies info fields, placeholders, or experience rows/columns. The model tracks every change and marks itself dirty. |
+| **Save** | The model is serialized back to the DA multi-sheet format and written to the DA Admin API via an authenticated PUT. |
+| **Preview** | A preview build is triggered via the DA Admin API. The tool surfaces a preview URL the author can open or copy. |
+| **Publish** | The manifest is auto-saved first, then pushed live via the DA Admin API. A live URL is surfaced for verification. |
+
+### File Browser
+
+The file browser provides navigation of the DA repository. It fetches directory listings from the DA Admin API, handles pagination transparently, and classifies items as folders, JSON sheets, or other documents. Only JSON sheets (manifest files) are actionable; all other file types are visible but non-interactive. Navigation is breadcrumb-based with path tracking.
+
+### Experience Grid — Columns & Rows
+
+The experiences grid is the most complex part of the tool:
+
+- **Columns are fully dynamic.** Any named audience segment (e.g., `all`, `target-returning-users`) can be added as a column. There is no fixed schema — the column set is discovered from the data.
+- **Rows are reorderable** via drag-and-drop, allowing authors to control the execution sequence of personalization rules.
+- **Adding a column** automatically adds an empty value for that column to every existing row, ensuring the model never has missing entries.
+- **Structural changes** (add/remove row or column) trigger a full grid re-render. Individual cell edits update only the model — no re-render — keeping the typing experience smooth.
+
+### Data Serialization
+
+The internal model and the DA wire format are two distinct representations. The tool handles bidirectional translation:
+
+- **On open:** The DA multi-sheet JSON is parsed into the internal model. Key matching is case-insensitive and normalizes hyphens, ensuring backwards compatibility with manifests created before the tool existed.
+- **On save:** The internal model is serialized back to the DA multi-sheet format, including all required pagination metadata fields.
+
+### API Communication
+
+All communication with the DA Admin API goes through a single adapter module. The adapter wraps five operations — list files, read manifest, save manifest, trigger preview, trigger publish — and handles authentication headers, pagination (via continuation tokens), and HTTP error mapping uniformly.
+
+---
+
+## UI Approach
+
+### Layout
+
+The app uses a fixed chrome layout with a scrollable content area:
+
+```
+┌────────────────────────────────────────────┐
+│  Toolbar — Save / Preview / Publish        │  48px
+├────────────────────────────────────────────┤
+│  Tab Nav — Experiences | Info | Placeholders│  40px
+├────────────────────────────────────────────┤
+│                                            │
+│  Tab Content (scrollable)                  │  flex: 1
+│                                            │
+├────────────────────────────────────────────┤
+│  Status Bar — Saved / Unsaved changes      │  24px
+└────────────────────────────────────────────┘
+```
+
+### Three Tabs
+
+| Tab | Purpose |
+|-----|---------|
+| **Experiences** | The main grid editor. Authors define experience rules as rows — each row specifies an action type, a CSS selector to target, an optional page filter, and content values per audience column. |
+| **Info** | Manifest metadata — type (personalization, test, promo), execution order (First, Normal, Last), and an optional analytics override name. |
+| **Placeholders** | A simple key/value list for reusable content tokens shared across experiences. |
+
+All three tab panels are rendered once at load time and toggled with CSS visibility. Tab switching does not re-render any content, which preserves scroll position and input focus state.
+
+### Experiences Grid
+
+The grid is an HTML table with a sticky header row. Each row represents one experience rule:
+
+- **Action column** — Dropdown with six MEP action types, each color-coded for instant visual differentiation (green, yellow, red, blue, pink, purple).
+- **Selector column** — Free-text CSS selector input.
+- **Page Filter column** — Free-text URL filter expression.
+- **Experience columns** — One text input per named audience segment. Columns with a `target` prefix are styled in a distinct shade to visually separate audience-targeted variants from the `all` default.
+- **Row handles** — Left-most column that acts as a drag handle for reordering, also showing the 1-indexed row number.
+- **Add column** — Header button that opens an inline modal to name and create a new experience column.
+
+### Action Color Coding
+
+Six visually distinct colors allow authors to scan a manifest at a glance and understand the distribution of action types without reading every cell:
+
+| Action | Color |
+|--------|-------|
+| Insert Content After | Green |
+| Replace Content | Yellow |
+| Remove | Red |
+| Insert Content Before | Blue |
+| Replace Fragment | Pink |
+| Append to Section | Purple |
+
+### Notifications & Feedback
+
+The tool uses two complementary feedback mechanisms:
+
+- **Status Bar (persistent):** Always visible at the bottom. Shows `Saved` in green after a successful write, and `Unsaved changes` in orange whenever the model is dirty. Provides a constant ambient indication of save state.
+- **Toast Notifications (transient):** Appear top-right on save/preview/publish completion. Success toasts include a URL, an "Open" button, and a "Copy URL" button. Error toasts include the failure reason. Both auto-dismiss after a short delay.
+
+### Design Language
+
+The UI follows Adobe Spectrum conventions — Adobe Blue as the primary action color, Typekit-loaded Adobe Clean as the typeface, and CSS custom properties for the full color palette. This matches the surrounding DA shell's visual language, making the tool feel native to the DA environment.
+
+---
+
+## Risks & Open Questions
+
+| # | Risk / Question | Priority |
+|---|----------------|----------|
+| 1 | **No automated tests.** The model's serialization logic (open → edit → save round-trip) is complex enough to warrant unit tests. Currently there is no test coverage. | High |
+| 2 | **No conflict detection on concurrent edits.** If two authors open the same manifest simultaneously, the last save wins. No optimistic locking or ETag-based conflict detection is in place. | Medium |
+| 3 | **Token expiry not handled.** If the DA bearer token expires mid-session, API calls will fail. There is no re-authentication flow — the author would need to reload the tool. | Medium |
+| 4 | **No grid virtualization.** All rows render to the DOM simultaneously. For manifests with a very large number of rows, this could cause performance degradation. Acceptable for typical manifest sizes today. | Low |
+| 5 | **MEP JSON export converter exists but is unused by the UI.** It is unclear if this was intended for a future "Export" feature or is leftover from an earlier approach. Should be either wired up or removed. | Low |

--- a/tools/mep-manifest/mep-manifest.css
+++ b/tools/mep-manifest/mep-manifest.css
@@ -1,0 +1,841 @@
+/* MEP Manifest Tool - Global Styles */
+:root {
+  --mep-bg: #f5f5f5;
+  --mep-surface: #ffffff;
+  --mep-border: #e0e0e0;
+  --mep-text: #2c2c2c;
+  --mep-text-secondary: #6e6e6e;
+  --mep-primary: #1473e6;
+  --mep-primary-hover: #0d66d0;
+  --mep-navy: #1b3a5c;
+  --mep-light-blue: #c8e1ff;
+  --mep-danger: #d7373f;
+  --mep-success: #12805c;
+  --mep-warning: #e68619;
+  --mep-font: 'Adobe Clean', 'adobe-clean', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --mep-radius: 4px;
+  --mep-toolbar-height: 48px;
+  --mep-tab-height: 40px;
+
+  /* Action colors */
+  --action-insert-after: #e6f4ea;
+  --action-insert-after-border: #34a853;
+  --action-replace: #fef7e0;
+  --action-replace-border: #f9ab00;
+  --action-remove: #fce8e6;
+  --action-remove-border: #ea4335;
+  --action-insert-before: #e8f0fe;
+  --action-insert-before-border: #4285f4;
+  --action-replace-fragment: #fce8f4;
+  --action-replace-fragment-border: #d93a8c;
+  --action-append-to-section: #f3e8fd;
+  --action-append-to-section-border: #9334e6;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--mep-font);
+  font-size: 14px;
+  color: var(--mep-text);
+  background: var(--mep-bg);
+  overflow: hidden;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* Toolbar */
+.mep-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--mep-toolbar-height);
+  padding: 0 12px;
+  background: var(--mep-surface);
+  border-bottom: 1px solid var(--mep-border);
+  flex-shrink: 0;
+}
+
+.mep-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mep-toolbar-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--mep-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.mep-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Buttons */
+.mep-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--mep-border);
+  border-radius: var(--mep-radius);
+  background: var(--mep-surface);
+  color: var(--mep-text);
+  font-family: var(--mep-font);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.mep-btn:hover {
+  background: #f0f0f0;
+  border-color: #ccc;
+}
+
+.mep-btn-primary {
+  background: var(--mep-primary);
+  color: #fff;
+  border-color: var(--mep-primary);
+}
+
+.mep-btn-primary:hover {
+  background: var(--mep-primary-hover);
+  border-color: var(--mep-primary-hover);
+}
+
+.mep-btn-icon {
+  width: 32px;
+  padding: 0;
+  font-size: 18px;
+}
+
+/* Tab Navigation */
+.mep-tabs {
+  display: flex;
+  align-items: stretch;
+  height: var(--mep-tab-height);
+  background: var(--mep-surface);
+  border-bottom: 1px solid var(--mep-border);
+  flex-shrink: 0;
+  padding: 0 12px;
+  gap: 0;
+}
+
+.mep-tab {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--mep-text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+  background: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font-family: var(--mep-font);
+}
+
+.mep-tab:hover {
+  color: var(--mep-text);
+}
+
+.mep-tab.active {
+  color: var(--mep-primary);
+  border-bottom-color: var(--mep-primary);
+}
+
+/* Tab Content */
+.mep-tab-content {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+}
+
+/* Info bar — horizontal inline strip at top of Experiences tab */
+.mep-info-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 0 12px;
+  border-bottom: 1px solid var(--mep-border);
+  margin-bottom: 12px;
+  flex-shrink: 0;
+}
+
+.mep-info-bar .mep-field {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+.mep-info-bar .mep-field-label {
+  white-space: nowrap;
+  text-transform: none;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.mep-info-bar .mep-select,
+.mep-info-bar .mep-input {
+  width: auto;
+  min-width: 120px;
+}
+
+/* Info Tab (legacy — file kept but no longer used in tabs) */
+.mep-info-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.mep-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mep-field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mep-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.mep-select,
+.mep-input {
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--mep-border);
+  border-radius: var(--mep-radius);
+  font-family: var(--mep-font);
+  font-size: 14px;
+  color: var(--mep-text);
+  background: var(--mep-surface);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.mep-select:focus,
+.mep-input:focus {
+  border-color: var(--mep-primary);
+}
+
+/* Placeholder Tab */
+.mep-placeholders {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 640px;
+}
+
+.mep-placeholder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mep-placeholder-row .mep-input {
+  flex: 1;
+}
+
+.mep-placeholder-row .mep-btn-icon {
+  color: var(--mep-danger);
+  border-color: transparent;
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.mep-placeholder-row .mep-btn-icon:hover {
+  background: var(--action-remove);
+}
+
+/* Experiences Grid */
+.mep-grid-wrapper {
+  overflow: auto;
+  flex: 1;
+}
+
+.mep-grid {
+  border-collapse: collapse;
+  min-width: 100%;
+  font-size: 13px;
+}
+
+.mep-grid th,
+.mep-grid td {
+  border: 1px solid var(--mep-border);
+  padding: 0;
+  min-width: 120px;
+  position: relative;
+}
+
+.mep-grid th {
+  height: 36px;
+  vertical-align: middle;
+}
+
+.mep-grid td {
+  height: auto;
+  min-height: 36px;
+  vertical-align: top;
+}
+
+/* Column resize handle */
+.mep-col-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  z-index: 1;
+}
+
+.mep-col-resize-handle:hover,
+.mep-col-resize-handle:active {
+  background: var(--mep-primary);
+  opacity: 0.4;
+}
+
+.mep-grid th {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 0 8px;
+  white-space: nowrap;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.mep-grid th.col-action {
+  background: #f0f0f0;
+  color: var(--mep-text);
+  min-width: 180px;
+}
+
+.mep-grid th.col-selector {
+  background: #f0f0f0;
+  color: var(--mep-text);
+  min-width: 200px;
+}
+
+.mep-grid th.col-page-filter {
+  background: #f0f0f0;
+  color: var(--mep-text);
+  min-width: 160px;
+}
+
+.mep-grid th.col-experience {
+  background: var(--mep-navy);
+  color: #fff;
+  min-width: 180px;
+}
+
+.mep-grid th.col-experience.target {
+  background: #4a90d9;
+}
+
+.mep-grid th.col-add {
+  background: #f0f0f0;
+  min-width: 40px;
+  width: 40px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.mep-grid th.col-add:hover {
+  background: #e0e0e0;
+}
+
+/* Row handle */
+.mep-grid td.col-handle {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  text-align: center;
+  color: var(--mep-text-secondary);
+  cursor: grab;
+  font-size: 12px;
+  vertical-align: middle;
+}
+
+.mep-grid td.col-handle:hover {
+  background: #f0f0f0;
+}
+
+/* Row delete */
+.mep-grid td.col-delete {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  text-align: center;
+  padding: 0;
+}
+
+.mep-grid td.col-delete button {
+  background: none;
+  border: none;
+  color: var(--mep-text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  width: 100%;
+  height: 100%;
+}
+
+.mep-grid td.col-delete button:hover {
+  color: var(--mep-danger);
+  background: var(--action-remove);
+}
+
+/* Cell wrapper — flex container for textarea + link button */
+.mep-grid td .cell-wrapper {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  min-height: 36px;
+}
+
+/* Textarea cell input (Selector + Experience columns) */
+.mep-grid td .cell-input {
+  flex: 1;
+  min-height: 36px;
+  height: auto;
+  border: none;
+  padding: 4px 8px;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  color: var(--mep-text);
+  background: transparent;
+  outline: none;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+/* Plain input cell (Page Filter) */
+.mep-grid td .cell-input-plain {
+  width: 100%;
+  height: 36px;
+  border: none;
+  padding: 4px 8px;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  color: var(--mep-text);
+  background: transparent;
+  outline: none;
+  white-space: nowrap;
+}
+
+.mep-grid td .cell-input:focus,
+.mep-grid td .cell-input-plain:focus {
+  background: #f0f7ff;
+}
+
+/* URL link button */
+.mep-grid td .cell-link-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin: 8px 3px 0 0;
+  font-size: 11px;
+  color: var(--mep-primary);
+  text-decoration: none;
+  flex-shrink: 0;
+  opacity: 0.65;
+  border-radius: 2px;
+}
+
+.mep-grid td .cell-link-btn:hover {
+  opacity: 1;
+  background: var(--mep-light-blue);
+}
+
+/* Action select */
+.mep-grid td .action-select {
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 4px 8px;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  color: var(--mep-text);
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+}
+
+.mep-grid td.action-cell {
+  padding: 0;
+}
+
+/* Action cell left-border accent (td only) */
+.mep-grid td.action-insertcontentafter  { border-left: 3px solid var(--action-insert-after-border); }
+.mep-grid td.action-replacecontent      { border-left: 3px solid var(--action-replace-border); }
+.mep-grid td.action-remove              { border-left: 3px solid var(--action-remove-border); }
+.mep-grid td.action-insertcontentbefore { border-left: 3px solid var(--action-insert-before-border); }
+.mep-grid td.action-replacefragment     { border-left: 3px solid var(--action-replace-fragment-border); }
+.mep-grid td.action-appendtosection     { border-left: 3px solid var(--action-append-to-section-border); }
+
+/* Full-row background tint */
+.mep-grid tr.row-insertcontentafter > td  { background: var(--action-insert-after); }
+.mep-grid tr.row-replacecontent > td      { background: var(--action-replace); }
+.mep-grid tr.row-remove > td              { background: var(--action-remove); }
+.mep-grid tr.row-insertcontentbefore > td { background: var(--action-insert-before); }
+.mep-grid tr.row-replacefragment > td     { background: var(--action-replace-fragment); }
+.mep-grid tr.row-appendtosection > td     { background: var(--action-append-to-section); }
+
+/* Grid footer */
+.mep-grid-footer {
+  padding: 8px 0;
+}
+
+/* Column name dialog */
+.mep-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.mep-dialog {
+  background: var(--mep-surface);
+  border-radius: 8px;
+  padding: 24px;
+  min-width: 320px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.mep-dialog h3 {
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+
+.mep-dialog .mep-field {
+  margin-bottom: 16px;
+}
+
+.mep-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* Status bar */
+.mep-status {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 12px;
+  font-size: 11px;
+  color: var(--mep-text-secondary);
+  background: var(--mep-surface);
+  border-top: 1px solid var(--mep-border);
+  flex-shrink: 0;
+}
+
+.mep-status-saved {
+  color: var(--mep-success);
+}
+
+.mep-status-unsaved {
+  color: var(--mep-warning);
+}
+
+/* File browser */
+.mep-file-browser {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.mep-file-browser-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--mep-border);
+}
+
+.mep-file-browser-header h2 {
+  font-size: 18px;
+}
+
+.mep-file-list {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+}
+
+.mep-file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--mep-radius);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.mep-file-item:hover {
+  background: #f0f0f0;
+}
+
+.mep-file-item.is-folder {
+  font-weight: 600;
+}
+
+.mep-file-item-icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
+}
+
+.mep-file-item-name {
+  flex: 1;
+}
+
+/* File browser legend */
+.mep-file-legend {
+  display: flex;
+  gap: 16px;
+  padding: 6px 16px;
+  font-size: 11px;
+  color: var(--mep-text-secondary);
+  border-bottom: 1px solid var(--mep-border);
+  background: #fafafa;
+}
+
+.mep-legend-sheet {
+  color: var(--mep-success);
+  font-weight: 600;
+}
+
+.mep-legend-doc {
+  color: #bbb;
+}
+
+/* Sheet item highlight */
+.mep-file-item.is-sheet .mep-file-item-name {
+  font-weight: 600;
+}
+
+/* File type label for inactive items */
+.mep-file-type-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: #bbb;
+  background: #f0f0f0;
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.5px;
+}
+
+/* Breadcrumb */
+.mep-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.mep-crumb {
+  background: none;
+  border: none;
+  color: var(--mep-primary);
+  cursor: pointer;
+  font-family: var(--mep-font);
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: var(--mep-radius);
+}
+
+.mep-crumb:hover {
+  background: #f0f0f0;
+}
+
+.mep-crumb-sep {
+  color: var(--mep-text-secondary);
+}
+
+/* File item active/inactive states */
+.mep-file-item.is-inactive {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.mep-file-open-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--mep-primary);
+  padding: 2px 8px;
+  border: 1px solid var(--mep-primary);
+  border-radius: var(--mep-radius);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.mep-file-item:hover .mep-file-open-label {
+  opacity: 1;
+}
+
+/* Toast notification */
+.mep-toast {
+  position: fixed;
+  top: calc(var(--mep-toolbar-height) + 8px);
+  right: 16px;
+  z-index: 200;
+  min-width: 320px;
+  max-width: 480px;
+  background: var(--mep-surface);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.18);
+  border-left: 4px solid var(--mep-success);
+  padding: 12px 14px;
+  animation: mep-toast-in 0.2s ease;
+}
+
+.mep-toast-error {
+  border-left-color: var(--mep-danger);
+}
+
+@keyframes mep-toast-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.mep-toast-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.mep-toast-icon {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--mep-success);
+}
+
+.mep-toast-error .mep-toast-icon {
+  color: var(--mep-danger);
+}
+
+.mep-toast-title {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--mep-text);
+}
+
+.mep-toast-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: var(--mep-text-secondary);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.mep-toast-close:hover {
+  color: var(--mep-text);
+}
+
+.mep-toast-url-row {
+  margin: 6px 0 4px;
+  overflow: hidden;
+}
+
+.mep-toast-url {
+  font-size: 11px;
+  color: var(--mep-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.mep-toast-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.mep-toast-btn {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.mep-toast-detail {
+  font-size: 12px;
+  color: var(--mep-danger);
+  margin-top: 4px;
+}
+
+/* Button loading state */
+.mep-btn-loading {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+/* Empty state */
+.mep-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 12px;
+  color: var(--mep-text-secondary);
+}
+
+.mep-empty-icon {
+  font-size: 48px;
+  opacity: 0.3;
+}

--- a/tools/mep-manifest/mep-manifest.css
+++ b/tools/mep-manifest/mep-manifest.css
@@ -595,72 +595,203 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  background: var(--mep-surface);
 }
 
+/* Single-row breadcrumb bar: org › site › path › NEW — matches DA pill style */
 .mep-file-browser-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px;
+  gap: 6px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--mep-border);
+  background: var(--mep-surface);
+  flex-wrap: wrap;
+  min-height: 52px;
 }
 
-.mep-file-browser-header h2 {
-  font-size: 18px;
+/* Breadcrumb pill chips */
+.mep-crumb {
+  background: #f5f5f5;
+  border: 1px solid #d8d8d8;
+  color: var(--mep-text);
+  cursor: pointer;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  padding: 4px 12px;
+  border-radius: 16px;
+  line-height: 1.4;
+  transition: background 0.15s, border-color 0.15s;
 }
 
+.mep-crumb:hover {
+  background: #e8e8e8;
+  border-color: #b8b8b8;
+}
+
+/* Org chip — static, not clickable */
+.mep-crumb.mep-crumb-static {
+  color: var(--mep-text);
+  cursor: default;
+  font-weight: 500;
+}
+
+.mep-crumb.mep-crumb-static:hover {
+  background: #f5f5f5;
+  border-color: #d8d8d8;
+}
+
+.mep-crumb-sep {
+  color: var(--mep-text-secondary);
+  font-size: 16px;
+  user-select: none;
+  line-height: 1;
+}
+
+/* NEW pill button */
+.mep-fb-new-btn {
+  background: var(--mep-primary);
+  color: #fff;
+  border: none;
+  border-radius: 16px;
+  padding: 5px 16px;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  line-height: 1.4;
+}
+
+.mep-fb-new-btn:hover {
+  background: var(--mep-primary-hover);
+}
+
+/* Inline new-file creation controls */
+.mep-fb-new-input {
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--mep-primary);
+  border-radius: 16px;
+  font-family: var(--mep-font);
+  font-size: 13px;
+  color: var(--mep-text);
+  outline: none;
+  width: 200px;
+  background: var(--mep-surface);
+}
+
+.mep-fb-new-input.mep-fb-input-error {
+  border-color: var(--mep-danger);
+}
+
+.mep-fb-new-create {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 13px;
+  border-radius: 16px;
+}
+
+.mep-fb-new-cancel {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 13px;
+  border-radius: 16px;
+}
+
+/* Column header row — checkbox + filter + NAME + MODIFIED */
+.mep-file-col-header {
+  display: flex;
+  align-items: center;
+  padding: 6px 16px 6px 20px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--mep-text-secondary);
+  border-bottom: 1px solid var(--mep-border);
+  background: var(--mep-surface);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.mep-file-col-check {
+  width: 20px;
+  height: 14px;
+  border: 1.5px solid #bbb;
+  border-radius: 3px;
+  display: inline-block;
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+
+.mep-file-col-filter {
+  font-size: 14px;
+  color: #bbb;
+  margin-right: 10px;
+  flex-shrink: 0;
+  cursor: default;
+  user-select: none;
+}
+
+.mep-file-col-name {
+  flex: 1;
+}
+
+.mep-file-col-modified {
+  width: 180px;
+  text-align: right;
+}
+
+/* File list — white, full-width rows */
 .mep-file-list {
   flex: 1;
   overflow: auto;
-  padding: 8px;
+  background: var(--mep-surface);
 }
 
 .mep-file-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: var(--mep-radius);
+  padding: 0 16px 0 20px;
+  min-height: 52px;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.12s;
+  border-bottom: 1px solid var(--mep-border);
+  background: var(--mep-surface);
 }
 
 .mep-file-item:hover {
-  background: #f0f0f0;
+  background: #f5f5f5;
 }
 
 .mep-file-item.is-folder {
   font-weight: 600;
 }
 
-.mep-file-item-icon {
-  font-size: 16px;
+/* Visual checkbox per row */
+.mep-file-item-check {
   width: 20px;
+  height: 14px;
+  border: 1.5px solid #d0d0d0;
+  border-radius: 3px;
+  display: inline-block;
+  flex-shrink: 0;
+  margin-right: 12px;
+}
+
+.mep-file-item-icon {
+  font-size: 18px;
+  width: 24px;
   text-align: center;
+  flex-shrink: 0;
+  margin-right: 12px;
 }
 
 .mep-file-item-name {
   flex: 1;
-}
-
-/* File browser legend */
-.mep-file-legend {
-  display: flex;
-  gap: 16px;
-  padding: 6px 16px;
-  font-size: 11px;
-  color: var(--mep-text-secondary);
-  border-bottom: 1px solid var(--mep-border);
-  background: #fafafa;
-}
-
-.mep-legend-sheet {
-  color: var(--mep-success);
-  font-weight: 600;
-}
-
-.mep-legend-doc {
-  color: #bbb;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Sheet item highlight */
@@ -668,60 +799,43 @@ body {
   font-weight: 600;
 }
 
-/* File type label for inactive items */
-.mep-file-type-label {
-  font-size: 10px;
-  font-weight: 600;
-  color: #bbb;
-  background: #f0f0f0;
-  padding: 1px 6px;
-  border-radius: 3px;
-  letter-spacing: 0.5px;
-}
-
-/* Breadcrumb */
-.mep-breadcrumb {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  font-size: 12px;
-}
-
-.mep-crumb {
-  background: none;
-  border: none;
-  color: var(--mep-primary);
-  cursor: pointer;
-  font-family: var(--mep-font);
-  font-size: 12px;
-  padding: 2px 4px;
-  border-radius: var(--mep-radius);
-}
-
-.mep-crumb:hover {
-  background: #f0f0f0;
-}
-
-.mep-crumb-sep {
+/* Modified date column */
+.mep-file-modified {
+  width: 180px;
+  text-align: right;
+  font-size: 13px;
   color: var(--mep-text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
-/* File item active/inactive states */
+/* Folder chevron — far right */
+.mep-file-item-chevron {
+  color: var(--mep-text-secondary);
+  font-size: 18px;
+  margin-left: 12px;
+  flex-shrink: 0;
+}
+
+/* Inactive items — subtle fade (non-sheet/folder files) */
 .mep-file-item.is-inactive {
-  opacity: 0.35;
+  opacity: 0.5;
   cursor: default;
   pointer-events: none;
 }
 
+/* "Open" pill — revealed on row hover */
 .mep-file-open-label {
   font-size: 11px;
   font-weight: 600;
   color: var(--mep-primary);
-  padding: 2px 8px;
+  padding: 2px 10px;
   border: 1px solid var(--mep-primary);
-  border-radius: var(--mep-radius);
+  border-radius: 10px;
   opacity: 0;
   transition: opacity 0.15s;
+  flex-shrink: 0;
+  margin-left: 12px;
 }
 
 .mep-file-item:hover .mep-file-open-label {

--- a/tools/mep-manifest/mep-manifest.css
+++ b/tools/mep-manifest/mep-manifest.css
@@ -18,18 +18,16 @@
   --mep-tab-height: 40px;
 
   /* Action colors */
-  --action-insert-after: #e6f4ea;
-  --action-insert-after-border: #34a853;
-  --action-replace: #fef7e0;
-  --action-replace-border: #f9ab00;
   --action-remove: #fce8e6;
   --action-remove-border: #ea4335;
-  --action-insert-before: #e8f0fe;
-  --action-insert-before-border: #4285f4;
-  --action-replace-fragment: #fce8f4;
-  --action-replace-fragment-border: #d93a8c;
-  --action-append-to-section: #f3e8fd;
-  --action-append-to-section-border: #9334e6;
+  --action-blue: #e8f0fe;
+  --action-blue-border: #4285f4;
+  --action-purple: #f3e8fd;
+  --action-purple-border: #9334e6;
+  --action-yellow: #fef7e0;
+  --action-yellow-border: #f9ab00;
+  --action-green: #e6f4ea;
+  --action-green-border: #34a853;
 }
 
 * {
@@ -506,20 +504,28 @@ body {
 }
 
 /* Action cell left-border accent (td only) */
-.mep-grid td.action-insertcontentafter  { border-left: 3px solid var(--action-insert-after-border); }
-.mep-grid td.action-replacecontent      { border-left: 3px solid var(--action-replace-border); }
-.mep-grid td.action-remove              { border-left: 3px solid var(--action-remove-border); }
-.mep-grid td.action-insertcontentbefore { border-left: 3px solid var(--action-insert-before-border); }
-.mep-grid td.action-replacefragment     { border-left: 3px solid var(--action-replace-fragment-border); }
-.mep-grid td.action-appendtosection     { border-left: 3px solid var(--action-append-to-section-border); }
+.mep-grid td.action-remove          { border-left: 3px solid var(--action-remove-border); }
+.mep-grid td.action-replace,
+.mep-grid td.action-insertbefore,
+.mep-grid td.action-insertafter,
+.mep-grid td.action-prependtosection,
+.mep-grid td.action-appendtosection { border-left: 3px solid var(--action-blue-border); }
+.mep-grid td.action-replacepage,
+.mep-grid td.action-useblockcode    { border-left: 3px solid var(--action-purple-border); }
+.mep-grid td.action-insertscript    { border-left: 3px solid var(--action-yellow-border); }
+.mep-grid td.action-updatemetadata  { border-left: 3px solid var(--action-green-border); }
 
 /* Full-row background tint */
-.mep-grid tr.row-insertcontentafter > td  { background: var(--action-insert-after); }
-.mep-grid tr.row-replacecontent > td      { background: var(--action-replace); }
-.mep-grid tr.row-remove > td              { background: var(--action-remove); }
-.mep-grid tr.row-insertcontentbefore > td { background: var(--action-insert-before); }
-.mep-grid tr.row-replacefragment > td     { background: var(--action-replace-fragment); }
-.mep-grid tr.row-appendtosection > td     { background: var(--action-append-to-section); }
+.mep-grid tr.row-remove > td                                    { background: var(--action-remove); }
+.mep-grid tr.row-replace > td,
+.mep-grid tr.row-insertbefore > td,
+.mep-grid tr.row-insertafter > td,
+.mep-grid tr.row-prependtosection > td,
+.mep-grid tr.row-appendtosection > td  { background: var(--action-blue); }
+.mep-grid tr.row-replacepage > td,
+.mep-grid tr.row-useblockcode > td     { background: var(--action-purple); }
+.mep-grid tr.row-insertscript > td     { background: var(--action-yellow); }
+.mep-grid tr.row-updatemetadata > td   { background: var(--action-green); }
 
 /* Grid footer */
 .mep-grid-footer {

--- a/tools/mep-manifest/mep-manifest.css
+++ b/tools/mep-manifest/mep-manifest.css
@@ -382,15 +382,39 @@ body {
   width: 32px;
   min-width: 32px;
   max-width: 32px;
-  text-align: center;
-  color: var(--mep-text-secondary);
-  cursor: grab;
-  font-size: 12px;
+  padding: 0;
   vertical-align: middle;
 }
 
-.mep-grid td.col-handle:hover {
+.mep-grid .drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 100%;
+  height: 100%;
+  min-height: 36px;
+  color: var(--mep-text-secondary);
+  font-size: 12px;
+  cursor: grab;
+  user-select: none;
+}
+
+.mep-grid .drag-handle:hover {
   background: #f0f0f0;
+}
+
+.mep-grid .drag-handle-grip {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.mep-grid tr.row-dragging {
+  opacity: 0.4;
+}
+
+.mep-grid tr.row-dragging .drag-handle {
+  cursor: grabbing;
 }
 
 /* Row delete */

--- a/tools/mep-manifest/mep-manifest.css
+++ b/tools/mep-manifest/mep-manifest.css
@@ -417,6 +417,15 @@ body {
   cursor: grabbing;
 }
 
+/* Drag insertion-line indicator */
+.mep-grid tr.drag-insert-before td {
+  box-shadow: inset 0 2px 0 0 var(--mep-primary);
+}
+
+.mep-grid tr.drag-insert-after td {
+  box-shadow: inset 0 -2px 0 0 var(--mep-primary);
+}
+
 /* Row delete */
 .mep-grid td.col-delete {
   width: 32px;

--- a/tools/mep-manifest/mep-manifest.html
+++ b/tools/mep-manifest/mep-manifest.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>MEP Manifest Tool</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="icon" href="data:,">
+    <!-- Import DA App SDK -->
+    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
+    <!-- Adobe Clean Font -->
+    <link rel="stylesheet" href="https://use.typekit.net/hah7vzn.css">
+    <!-- App Styles -->
+    <link rel="stylesheet" href="/tools/mep-manifest/mep-manifest.css"/>
+    <!-- App Logic -->
+    <script src="/tools/mep-manifest/mep-manifest.js" type="module"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/tools/mep-manifest/mep-manifest.js
+++ b/tools/mep-manifest/mep-manifest.js
@@ -1,0 +1,32 @@
+import { initApp } from './src/app.js';
+
+async function init() {
+  // Default mock context for fully standalone local dev (no DA shell parent)
+  let context = { org: 'sharg1', repo: 'da-block-collection' };
+  let token = '';
+  let actions = { sendText: () => {}, closeLibrary: () => {} };
+
+  try {
+    // Always attempt the DA SDK — it communicates via postMessage with the
+    // parent DA shell, so it works even when the iframe is served from localhost
+    // (e.g. da.live?ref=local). Race against a 4s timeout so standalone local
+    // dev (no DA shell parent) falls back to mock values instead of hanging.
+    // eslint-disable-next-line import/no-unresolved
+    const sdkModule = await import('https://da.live/nx/utils/sdk.js');
+    const sdk = await Promise.race([
+      sdkModule.default,
+      new Promise((resolve) => { setTimeout(() => resolve(null), 4000); }),
+    ]);
+    if (sdk?.context) {
+      context = sdk.context;
+      token = sdk.token;
+      actions = sdk.actions;
+    }
+  } catch (e) {
+    // Running fully standalone without a DA shell — keep mock values
+  }
+
+  initApp(document.getElementById('app'), { context, token, actions });
+}
+
+init();

--- a/tools/mep-manifest/src/app.js
+++ b/tools/mep-manifest/src/app.js
@@ -1,0 +1,271 @@
+import { ManifestModel } from './data/manifest-model.js';
+import { openManifest, saveManifest, previewManifest, publishManifest, setToken } from './data/da-sheet-adapter.js';
+import { renderFileBrowser } from './ui/file-browser.js';
+import { renderToolbar, setButtonLoading } from './ui/toolbar.js';
+import { renderTabNav } from './ui/tab-nav.js';
+import { renderPlaceholdersTab } from './ui/placeholders-tab.js';
+import { renderExperiencesTab } from './ui/experiences-tab.js';
+import { renderStatusBar, setStatus } from './ui/status-bar.js';
+import { showToast } from './ui/toast.js';
+
+let model = ManifestModel.createNew();
+let statusBar;
+let sdk = {};
+let tabs = {};
+let appContainer;
+let previewBtn;
+let publishBtn;
+
+function getOrgSite() {
+  const { org, repo } = sdk.context || {};
+  return { org: org || '', site: repo || '' };
+}
+
+/* ---- New Manifest Modal ---- */
+
+function showNewManifestDialog(prefillPath, onConfirm) {
+  // Prevent duplicate dialogs
+  if (document.querySelector('.mep-new-manifest-dialog')) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'mep-dialog-overlay';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'mep-dialog mep-new-manifest-dialog';
+
+  const h3 = document.createElement('h3');
+  h3.textContent = 'New Manifest';
+
+  // Location field
+  const locationField = document.createElement('div');
+  locationField.className = 'mep-field';
+  const locationLabel = document.createElement('label');
+  locationLabel.className = 'mep-field-label';
+  locationLabel.textContent = 'Location (folder)';
+  const locationInput = document.createElement('input');
+  locationInput.className = 'mep-input';
+  locationInput.type = 'text';
+  locationInput.placeholder = 'e.g., fragments/tests';
+  locationInput.value = prefillPath || '';
+  locationField.append(locationLabel, locationInput);
+
+  // Name field
+  const nameField = document.createElement('div');
+  nameField.className = 'mep-field';
+  const nameLabel = document.createElement('label');
+  nameLabel.className = 'mep-field-label';
+  nameLabel.textContent = 'Name (no extension)';
+  const nameInput = document.createElement('input');
+  nameInput.className = 'mep-input';
+  nameInput.type = 'text';
+  nameInput.placeholder = 'my-manifest';
+  nameField.append(nameLabel, nameInput);
+
+  const errorMsg = document.createElement('p');
+  errorMsg.className = 'mep-dialog-error';
+  errorMsg.style.cssText = 'color:var(--mep-danger);font-size:12px;margin-top:4px;display:none';
+
+  const actions = document.createElement('div');
+  actions.className = 'mep-dialog-actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'mep-btn';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => overlay.remove());
+
+  const createBtn = document.createElement('button');
+  createBtn.className = 'mep-btn mep-btn-primary';
+  createBtn.textContent = 'Create';
+  createBtn.addEventListener('click', () => {
+    const name = nameInput.value.trim();
+    if (!name) {
+      errorMsg.textContent = 'Name is required.';
+      errorMsg.style.display = '';
+      nameInput.focus();
+      return;
+    }
+    const folder = locationInput.value.trim().replace(/^\/|\/$/g, '');
+    const filePath = folder ? `${folder}/${name}.json` : `${name}.json`;
+    overlay.remove();
+    onConfirm(filePath);
+  });
+
+  overlay.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') overlay.remove();
+    if (e.key === 'Enter' && document.activeElement !== cancelBtn) createBtn.click();
+  });
+
+  actions.append(cancelBtn, createBtn);
+  dialog.append(h3, locationField, nameField, errorMsg, actions);
+  overlay.append(dialog);
+  document.body.append(overlay);
+
+  requestAnimationFrame(() => nameInput.focus());
+}
+
+/* ---- File browser ---- */
+
+function showFileBrowser() {
+  appContainer.innerHTML = '';
+  const { org, site } = getOrgSite();
+  renderFileBrowser(appContainer, {
+    org,
+    site,
+    startPath: '',
+    onOpen: (path) => handleOpen(path),
+    onNew: (folderPath) => handleNew(folderPath),
+  });
+}
+
+/* ---- Editor actions ---- */
+
+async function handleSave() {
+  const { org, site } = getOrgSite();
+  const sheetData = model.toSheet();
+
+  try {
+    setStatus(statusBar, 'Saving...', '');
+    await saveManifest(org, site, model.filePath, sheetData);
+    model.markClean();
+    model.emit();
+    setStatus(statusBar, 'Saved', 'saved');
+  } catch (err) {
+    setStatus(statusBar, `Save failed: ${err.message}`, 'unsaved');
+  }
+}
+
+async function handlePreview() {
+  if (!model.filePath) {
+    // eslint-disable-next-line no-alert
+    alert('Please save the manifest first.');
+    return;
+  }
+  await handleSave();
+  const { org, site } = getOrgSite();
+  setButtonLoading(previewBtn, true, 'Previewing…');
+  setStatus(statusBar, 'Generating preview…', '');
+  try {
+    await previewManifest(org, site, model.filePath);
+    const pagePath = model.filePath.replace(/\.[^/.]+$/, '');
+    const url = `https://main--${site}--${org}.aem.page/${pagePath}`;
+    setStatus(statusBar, 'Preview ready', 'saved');
+    showToast('success', 'Preview generated', { url });
+  } catch (err) {
+    setStatus(statusBar, `Preview failed: ${err.message}`, 'unsaved');
+    showToast('error', 'Preview failed', { detail: err.message });
+  } finally {
+    setButtonLoading(previewBtn, false);
+  }
+}
+
+async function handlePublish() {
+  if (!model.filePath) {
+    // eslint-disable-next-line no-alert
+    alert('Please save the manifest first.');
+    return;
+  }
+  await handleSave();
+  const { org, site } = getOrgSite();
+  setButtonLoading(publishBtn, true, 'Publishing…');
+  setStatus(statusBar, 'Publishing…', '');
+  try {
+    await publishManifest(org, site, model.filePath);
+    const pagePath = model.filePath.replace(/\.[^/.]+$/, '');
+    const url = `https://main--${site}--${org}.aem.live/${pagePath}`;
+    setStatus(statusBar, 'Published', 'saved');
+    showToast('success', 'Published to live', { url });
+  } catch (err) {
+    setStatus(statusBar, `Publish failed: ${err.message}`, 'unsaved');
+    showToast('error', 'Publish failed', { detail: err.message });
+  } finally {
+    setButtonLoading(publishBtn, false);
+  }
+}
+
+function handleNew(prefillPath = '') {
+  // eslint-disable-next-line no-restricted-globals, no-alert
+  if (model.dirty && !confirm('Discard unsaved changes?')) return;
+  showNewManifestDialog(prefillPath, (filePath) => {
+    model = ManifestModel.createNew();
+    model.filePath = filePath;
+    renderEditor();
+  });
+}
+
+function handleClose() {
+  // eslint-disable-next-line no-restricted-globals, no-alert
+  if (model.dirty && !confirm('Discard unsaved changes?')) return;
+  model = ManifestModel.createNew();
+  showFileBrowser();
+}
+
+async function handleOpen(path) {
+  const { org, site } = getOrgSite();
+  try {
+    const data = await openManifest(org, site, path);
+    model = new ManifestModel();
+    model.filePath = path;
+    if (data) model.fromSheet(data);
+    renderEditor();
+  } catch (err) {
+    // eslint-disable-next-line no-alert
+    alert(`Could not open file: ${err.message}`);
+  }
+}
+
+function switchTab(tabId) {
+  Object.keys(tabs).forEach((id) => {
+    const tabEl = tabs[id]?.el || tabs[id];
+    if (tabEl) tabEl.style.display = id === tabId ? '' : 'none';
+  });
+}
+
+/* ---- Render ---- */
+
+function renderEditor() {
+  appContainer.innerHTML = '';
+
+  // Derive folder from current file path for the toolbar "+ New" button
+  const currentFolder = model.filePath
+    ? model.filePath.slice(0, model.filePath.lastIndexOf('/'))
+    : '';
+
+  ({ previewBtn, publishBtn } = renderToolbar(appContainer, {
+    onSave: handleSave,
+    onPreview: handlePreview,
+    onPublish: handlePublish,
+    onNew: () => handleNew(currentFolder),
+    onClose: handleClose,
+    model,
+  }));
+
+  renderTabNav(appContainer, switchTab);
+
+  const experiencesTab = renderExperiencesTab(appContainer, model);
+  const placeholdersResult = renderPlaceholdersTab(appContainer, model);
+
+  tabs = {
+    experiences: experiencesTab,
+    placeholders: placeholdersResult,
+  };
+
+  // Hide non-active tabs
+  switchTab('experiences');
+
+  statusBar = renderStatusBar(appContainer, model);
+}
+
+export function initApp(container, sdkData) {
+  sdk = sdkData;
+  appContainer = container;
+  setToken(sdk.token);
+
+  // Check URL for a direct file path to auto-open
+  const urlParams = new URLSearchParams(window.location.search);
+  const openPath = urlParams.get('path');
+  if (openPath) {
+    handleOpen(openPath);
+  } else {
+    showFileBrowser();
+  }
+}

--- a/tools/mep-manifest/src/app.js
+++ b/tools/mep-manifest/src/app.js
@@ -113,7 +113,13 @@ function showFileBrowser() {
     site,
     startPath: '',
     onOpen: (path) => handleOpen(path),
-    onNew: (folderPath) => handleNew(folderPath),
+    onNew: (filePath) => {
+      // eslint-disable-next-line no-restricted-globals, no-alert
+      if (model.dirty && !confirm('Discard unsaved changes?')) return;
+      model = ManifestModel.createNew();
+      model.filePath = filePath;
+      renderEditor();
+    },
   });
 }
 

--- a/tools/mep-manifest/src/data/da-sheet-adapter.js
+++ b/tools/mep-manifest/src/data/da-sheet-adapter.js
@@ -1,0 +1,97 @@
+const DA_ADMIN = 'https://admin.da.live';
+
+let _token = '';
+
+export function setToken(token) {
+  _token = token || '';
+}
+
+function authHeaders(extra = {}) {
+  return _token ? { Authorization: `Bearer ${_token}`, ...extra } : extra;
+}
+
+function buildSourceUrl(org, site, path) {
+  return `${DA_ADMIN}/source/${org}/${site}/${path}`;
+}
+
+/**
+ * List files/folders at a given path using the DA list API.
+ * Handles pagination via da-continuation-token to return ALL items.
+ * Returns an array of { name, path, ext } items — folders have no ext.
+ */
+export async function listFiles(org, site, folder) {
+  const cleanFolder = (folder || '').replace(/^\/|\/$/g, '');
+  const base = `${DA_ADMIN}/list/${org}/${site}${cleanFolder ? `/${cleanFolder}` : ''}`;
+
+  let allItems = [];
+  let continuationToken = null;
+
+  do {
+    const headers = authHeaders(continuationToken ? { 'da-continuation-token': continuationToken } : {});
+
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await fetch(base, { headers });
+    if (!resp.ok) throw new Error(`Failed to list files: ${resp.status}`);
+
+    // eslint-disable-next-line no-await-in-loop
+    const data = await resp.json();
+    const items = Array.isArray(data) ? data : (data.items || []);
+    allItems = allItems.concat(items);
+
+    continuationToken = resp.headers.get('da-continuation-token');
+  } while (continuationToken);
+
+  return allItems;
+}
+
+/**
+ * Open a manifest sheet from DA.
+ */
+export async function openManifest(org, site, path) {
+  const normalizedPath = path.endsWith('.json') ? path : `${path}.json`;
+  const url = buildSourceUrl(org, site, normalizedPath);
+  const resp = await fetch(url, { headers: authHeaders() });
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw new Error(`Failed to open manifest: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+/**
+ * Save manifest data as a DA sheet.
+ */
+export async function saveManifest(org, site, path, data) {
+  const url = buildSourceUrl(org, site, path);
+  const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+  const formData = new FormData();
+  formData.append('data', blob);
+
+  const resp = await fetch(url, { method: 'PUT', body: formData, headers: authHeaders() });
+  if (!resp.ok) throw new Error(`Failed to save manifest: ${resp.status}`);
+  return resp;
+}
+
+/**
+ * Preview a manifest (triggers DA preview).
+ * DA admin preview/live APIs operate on page paths (no file extension).
+ */
+export async function previewManifest(org, site, path) {
+  const pagePath = path.replace(/\.[^/.]+$/, '');
+  const url = `${DA_ADMIN}/preview/${org}/${site}/${pagePath}`;
+  const resp = await fetch(url, { method: 'POST', headers: authHeaders() });
+  if (!resp.ok) throw new Error(`Failed to preview: ${resp.status}`);
+  return resp.json();
+}
+
+/**
+ * Publish a manifest (triggers DA publish).
+ * DA admin preview/live APIs operate on page paths (no file extension).
+ */
+export async function publishManifest(org, site, path) {
+  const pagePath = path.replace(/\.[^/.]+$/, '');
+  const url = `${DA_ADMIN}/live/${org}/${site}/${pagePath}`;
+  const resp = await fetch(url, { method: 'POST', headers: authHeaders() });
+  if (!resp.ok) throw new Error(`Failed to publish: ${resp.status}`);
+  return resp.json();
+}

--- a/tools/mep-manifest/src/data/json-converter.js
+++ b/tools/mep-manifest/src/data/json-converter.js
@@ -1,0 +1,51 @@
+/**
+ * Converts ManifestModel to MEP JSON format for preview/publish.
+ *
+ * MEP JSON format:
+ * {
+ *   "info": {
+ *     "manifesttype": "personalization",
+ *     "executionorder": "Normal",
+ *     "overridename": ""
+ *   },
+ *   "placeholders": { "key1": "val1", ... },
+ *   "experiences": [
+ *     {
+ *       "action": "replaceContent",
+ *       "selector": ".hero",
+ *       "page filter": "",
+ *       "experience-name": "/path/to/fragment"
+ *     },
+ *     ...
+ *   ]
+ * }
+ */
+export function toMepJson(model) {
+  const info = {};
+  if (model.info.type) info.manifesttype = model.info.type;
+  if (model.info.executionOrder) info.executionorder = model.info.executionOrder;
+  if (model.info.overrideName) info.overridename = model.info.overrideName;
+
+  const placeholders = {};
+  model.placeholders.forEach((ph) => {
+    if (ph.key) placeholders[ph.key] = ph.value;
+  });
+
+  const experiences = model.experiences.rows.map((row) => {
+    const exp = {};
+    if (row.action) exp.action = row.action;
+    if (row.selector) exp.selector = row.selector;
+    if (row.pageFilter) exp['page filter'] = row.pageFilter;
+    model.experiences.columns.forEach((col) => {
+      const val = row.values[col.name];
+      if (val !== undefined) exp[col.name] = val;
+    });
+    return exp;
+  });
+
+  return {
+    info,
+    placeholders,
+    experiences,
+  };
+}

--- a/tools/mep-manifest/src/data/manifest-model.js
+++ b/tools/mep-manifest/src/data/manifest-model.js
@@ -160,12 +160,17 @@ export class ManifestModel {
     // Load experiences
     const expData = sheetData.experiences?.data || sheetData.data || [];
     if (expData.length > 0) {
-      // Discover columns from first row keys
-      const fixedCols = ['action', 'selector', 'pagefilter', 'page filter'];
+      // Case-insensitive key lookup
+      const getVal = (row, key) => {
+        const lk = key.toLowerCase();
+        const found = Object.keys(row).find((k) => k.toLowerCase() === lk);
+        return found ? (row[found] || '') : '';
+      };
+
+      // Discover columns from first row keys, excluding fixed ones
+      const fixedCols = ['action', 'selector', 'page filter', 'pagefilter'];
       const allKeys = Object.keys(expData[0]);
-      const expColNames = allKeys.filter(
-        (k) => !fixedCols.includes(k.toLowerCase()) && k !== 'Action' && k !== 'Selector' && k !== 'Page Filter',
-      );
+      const expColNames = allKeys.filter((k) => !fixedCols.includes(k.toLowerCase()));
 
       this.experiences.columns = expColNames.map((name) => ({ name }));
       this.experiences.rows = expData.map((row) => {
@@ -174,9 +179,9 @@ export class ManifestModel {
           values[name] = row[name] || '';
         });
         return {
-          action: row.Action || '',
-          selector: row.Selector || '',
-          pageFilter: row['Page Filter'] || '',
+          action: getVal(row, 'action'),
+          selector: getVal(row, 'selector'),
+          pageFilter: getVal(row, 'page filter'),
           values,
         };
       });

--- a/tools/mep-manifest/src/data/manifest-model.js
+++ b/tools/mep-manifest/src/data/manifest-model.js
@@ -1,0 +1,253 @@
+/**
+ * MEP Manifest data model.
+ * Holds all manifest data and emits change events.
+ */
+
+const ACTIONS = [
+  'insertContentAfter',
+  'replaceContent',
+  'remove',
+  'insertContentBefore',
+  'replaceFragment',
+  'appendToSection',
+];
+
+const MANIFEST_TYPES = ['personalization', 'test', 'promo'];
+const EXECUTION_ORDERS = ['First', 'Normal', 'Last'];
+
+export { ACTIONS, MANIFEST_TYPES, EXECUTION_ORDERS };
+
+export class ManifestModel {
+  constructor() {
+    this.info = {
+      type: 'personalization',
+      executionOrder: 'Normal',
+      overrideName: '',
+    };
+    this.placeholders = [];
+    this.experiences = {
+      columns: [],
+      rows: [],
+    };
+    this.dirty = false;
+    this.listeners = [];
+    this.filePath = '';
+  }
+
+  onChange(fn) {
+    this.listeners.push(fn);
+  }
+
+  emit() {
+    this.dirty = true;
+    this.listeners.forEach((fn) => fn(this));
+  }
+
+  /* ---- Info ---- */
+
+  setInfo(key, value) {
+    this.info[key] = value;
+    this.emit();
+  }
+
+  /* ---- Placeholders ---- */
+
+  addPlaceholder(key = '', value = '') {
+    this.placeholders.push({ key, value });
+    this.emit();
+  }
+
+  updatePlaceholder(idx, field, value) {
+    this.placeholders[idx][field] = value;
+    this.emit();
+  }
+
+  removePlaceholder(idx) {
+    this.placeholders.splice(idx, 1);
+    this.emit();
+  }
+
+  /* ---- Experience Columns ---- */
+
+  addColumn(name) {
+    this.experiences.columns.push({ name });
+    // Add empty value for this column to all existing rows
+    this.experiences.rows.forEach((row) => {
+      row.values[name] = '';
+    });
+    this.emit();
+  }
+
+  removeColumn(idx) {
+    const col = this.experiences.columns[idx];
+    this.experiences.columns.splice(idx, 1);
+    this.experiences.rows.forEach((row) => {
+      delete row.values[col.name];
+    });
+    this.emit();
+  }
+
+  /* ---- Experience Rows ---- */
+
+  addRow() {
+    const values = {};
+    this.experiences.columns.forEach((col) => {
+      values[col.name] = '';
+    });
+    this.experiences.rows.push({
+      action: '',
+      selector: '',
+      pageFilter: '',
+      values,
+    });
+    this.emit();
+  }
+
+  updateRow(rowIdx, field, value) {
+    this.experiences.rows[rowIdx][field] = value;
+    this.emit();
+  }
+
+  updateRowValue(rowIdx, colName, value) {
+    this.experiences.rows[rowIdx].values[colName] = value;
+    this.emit();
+  }
+
+  removeRow(idx) {
+    this.experiences.rows.splice(idx, 1);
+    this.emit();
+  }
+
+  moveRow(fromIdx, toIdx) {
+    const [row] = this.experiences.rows.splice(fromIdx, 1);
+    this.experiences.rows.splice(toIdx, 0, row);
+    this.emit();
+  }
+
+  /* ---- Serialization: to/from DA sheet format ---- */
+
+  /**
+   * Load from DA multi-sheet JSON format.
+   * Expected structure:
+   * {
+   *   ":names": ["experiences", "info", "placeholders"],
+   *   "info": { "data": [{ "Key": "...", "Value": "..." }, ...] },
+   *   "placeholders": { "data": [{ "Key": "...", "Value": "..." }, ...] },
+   *   "experiences": { "data": [{ "Action": "...", "Selector": "...", ... }, ...] }
+   * }
+   */
+  fromSheet(sheetData) {
+    if (!sheetData) return;
+
+    // Load info
+    const infoData = sheetData.info?.data || sheetData[':names']?.includes('info')
+      ? (sheetData.info?.data || [])
+      : [];
+    infoData.forEach((row) => {
+      const key = (row.Key || '').toLowerCase().replace(/\s+/g, '');
+      if (key === 'manifesttype' || key === 'manifest-type') this.info.type = row.Value || 'personalization';
+      if (key === 'executionorder' || key === 'execution-order') this.info.executionOrder = row.Value || 'Normal';
+      if (key === 'overridename' || key === 'override-name') this.info.overrideName = row.Value || '';
+    });
+
+    // Load placeholders
+    const phData = sheetData.placeholders?.data || [];
+    this.placeholders = phData.map((row) => ({
+      key: row.Key || '',
+      value: row.Value || '',
+    }));
+
+    // Load experiences
+    const expData = sheetData.experiences?.data || sheetData.data || [];
+    if (expData.length > 0) {
+      // Discover columns from first row keys
+      const fixedCols = ['action', 'selector', 'pagefilter', 'page filter'];
+      const allKeys = Object.keys(expData[0]);
+      const expColNames = allKeys.filter(
+        (k) => !fixedCols.includes(k.toLowerCase()) && k !== 'Action' && k !== 'Selector' && k !== 'Page Filter',
+      );
+
+      this.experiences.columns = expColNames.map((name) => ({ name }));
+      this.experiences.rows = expData.map((row) => {
+        const values = {};
+        expColNames.forEach((name) => {
+          values[name] = row[name] || '';
+        });
+        return {
+          action: row.Action || '',
+          selector: row.Selector || '',
+          pageFilter: row['Page Filter'] || '',
+          values,
+        };
+      });
+    }
+
+    this.dirty = false;
+  }
+
+  /**
+   * Convert to DA multi-sheet JSON format for saving.
+   */
+  toSheet() {
+    const infoData = [
+      { Key: 'manifest-type', Value: this.info.type },
+      { Key: 'execution-order', Value: this.info.executionOrder },
+      { Key: 'override-name', Value: this.info.overrideName },
+    ];
+
+    const placeholderData = this.placeholders.map((ph) => ({
+      Key: ph.key,
+      Value: ph.value,
+    }));
+
+    const expData = this.experiences.rows.map((row) => {
+      const obj = {
+        Action: row.action,
+        Selector: row.selector,
+        'Page Filter': row.pageFilter,
+      };
+      this.experiences.columns.forEach((col) => {
+        obj[col.name] = row.values[col.name] || '';
+      });
+      return obj;
+    });
+
+    return {
+      ':type': 'multi-sheet',
+      ':names': ['experiences', 'info', 'placeholders'],
+      ':version': 3,
+      experiences: {
+        total: expData.length,
+        offset: 0,
+        limit: expData.length,
+        data: expData,
+      },
+      info: {
+        total: infoData.length,
+        offset: 0,
+        limit: infoData.length,
+        data: infoData,
+      },
+      placeholders: {
+        total: placeholderData.length,
+        offset: 0,
+        limit: placeholderData.length,
+        data: placeholderData,
+      },
+    };
+  }
+
+  markClean() {
+    this.dirty = false;
+  }
+
+  /**
+   * Create a new empty manifest.
+   */
+  static createNew() {
+    const model = new ManifestModel();
+    model.addColumn('all');
+    model.addRow();
+    return model;
+  }
+}

--- a/tools/mep-manifest/src/data/manifest-model.js
+++ b/tools/mep-manifest/src/data/manifest-model.js
@@ -4,12 +4,16 @@
  */
 
 const ACTIONS = [
-  'insertContentAfter',
-  'replaceContent',
   'remove',
-  'insertContentBefore',
-  'replaceFragment',
+  'replace',
+  'insertBefore',
+  'insertAfter',
+  'prependToSection',
   'appendToSection',
+  'replacePage',
+  'useBlockCode',
+  'insertScript',
+  'updateMetadata',
 ];
 
 const MANIFEST_TYPES = ['personalization', 'test', 'promo'];

--- a/tools/mep-manifest/src/data/manifest-model.js
+++ b/tools/mep-manifest/src/data/manifest-model.js
@@ -172,7 +172,7 @@ export class ManifestModel {
       };
 
       // Discover columns from first row keys, excluding fixed ones
-      const fixedCols = ['action', 'selector', 'page filter', 'pagefilter'];
+      const fixedCols = ['action', 'selector', 'page filter', 'pagefilter', 'page filter (optional)'];
       const allKeys = Object.keys(expData[0]);
       const expColNames = allKeys.filter((k) => !fixedCols.includes(k.toLowerCase()));
 
@@ -185,7 +185,7 @@ export class ManifestModel {
         return {
           action: getVal(row, 'action'),
           selector: getVal(row, 'selector'),
-          pageFilter: getVal(row, 'page filter'),
+          pageFilter: getVal(row, 'page filter') || getVal(row, 'page filter (optional)'),
           values,
         };
       });

--- a/tools/mep-manifest/src/ui/experiences-tab.js
+++ b/tools/mep-manifest/src/ui/experiences-tab.js
@@ -1,0 +1,416 @@
+import { ACTIONS, MANIFEST_TYPES, EXECUTION_ORDERS } from '../data/manifest-model.js';
+
+// Maps action name → CSS class for the action <td> left-border accent
+const ACTION_CSS_MAP = {
+  insertContentAfter: 'action-insertcontentafter',
+  replaceContent: 'action-replacecontent',
+  remove: 'action-remove',
+  insertContentBefore: 'action-insertcontentbefore',
+  replaceFragment: 'action-replacefragment',
+  appendToSection: 'action-appendtosection',
+};
+
+// Maps action name → CSS class applied to the entire <tr> for row background
+const ROW_CSS_MAP = {
+  insertContentAfter: 'row-insertcontentafter',
+  replaceContent: 'row-replacecontent',
+  remove: 'row-remove',
+  insertContentBefore: 'row-insertcontentbefore',
+  replaceFragment: 'row-replacefragment',
+  appendToSection: 'row-appendtosection',
+};
+
+/**
+ * Renders the Experiences tab — includes an inline info bar at the top
+ * (Manifest Type, Execution Order, Override Name) followed by the main grid.
+ */
+export function renderExperiencesTab(container, model) {
+  const wrap = document.createElement('div');
+  wrap.className = 'mep-tab-content';
+  wrap.id = 'tab-experiences';
+
+  // ---- Info bar (built once, outside render()) ----
+  const infoBar = document.createElement('div');
+  infoBar.className = 'mep-info-bar';
+
+  // Manifest Type
+  const typeField = document.createElement('div');
+  typeField.className = 'mep-field';
+  const typeLabel = document.createElement('label');
+  typeLabel.className = 'mep-field-label';
+  typeLabel.textContent = 'Manifest Type';
+  const typeSelect = document.createElement('select');
+  typeSelect.className = 'mep-select';
+  MANIFEST_TYPES.forEach((t) => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    if (t === model.info.type) opt.selected = true;
+    typeSelect.append(opt);
+  });
+  typeSelect.addEventListener('change', (e) => model.setInfo('type', e.target.value));
+  typeField.append(typeLabel, typeSelect);
+
+  // Execution Order
+  const orderField = document.createElement('div');
+  orderField.className = 'mep-field';
+  const orderLabel = document.createElement('label');
+  orderLabel.className = 'mep-field-label';
+  orderLabel.textContent = 'Execution Order';
+  const orderSelect = document.createElement('select');
+  orderSelect.className = 'mep-select';
+  EXECUTION_ORDERS.forEach((o) => {
+    const opt = document.createElement('option');
+    opt.value = o;
+    opt.textContent = o;
+    if (o === model.info.executionOrder) opt.selected = true;
+    orderSelect.append(opt);
+  });
+  orderSelect.addEventListener('change', (e) => model.setInfo('executionOrder', e.target.value));
+  orderField.append(orderLabel, orderSelect);
+
+  // Override Name
+  const nameField = document.createElement('div');
+  nameField.className = 'mep-field';
+  const nameLabel = document.createElement('label');
+  nameLabel.className = 'mep-field-label';
+  nameLabel.textContent = 'Override Name';
+  const nameInput = document.createElement('input');
+  nameInput.className = 'mep-input';
+  nameInput.type = 'text';
+  nameInput.placeholder = 'optional';
+  nameInput.value = model.info.overrideName || '';
+  nameInput.addEventListener('change', (e) => model.setInfo('overrideName', e.target.value));
+  nameField.append(nameLabel, nameInput);
+
+  infoBar.append(typeField, orderField, nameField);
+  wrap.append(infoBar);
+
+  // ---- Grid (rebuilt on each render()) ----
+  function render() {
+    // Remove everything after the info bar
+    while (wrap.lastChild !== infoBar) wrap.removeChild(wrap.lastChild);
+
+    const gridWrapper = document.createElement('div');
+    gridWrapper.className = 'mep-grid-wrapper';
+
+    const table = document.createElement('table');
+    table.className = 'mep-grid';
+
+    // Header
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+
+    headerRow.append(createTh('#', 'col-handle'));
+    headerRow.append(createTh('Action', 'col-action', true));
+    headerRow.append(createTh('Selector', 'col-selector', true));
+    headerRow.append(createTh('Page Filter', 'col-page-filter', true));
+
+    model.experiences.columns.forEach((col) => {
+      const isTarget = col.name.toLowerCase().startsWith('target');
+      headerRow.append(createTh(col.name, `col-experience${isTarget ? ' target' : ''}`, true));
+    });
+
+    const addColTh = document.createElement('th');
+    addColTh.className = 'col-add';
+    addColTh.textContent = '+';
+    addColTh.title = 'Add Experience Column';
+    addColTh.addEventListener('click', () => showAddColumnDialog(model, render));
+    headerRow.append(addColTh);
+
+    headerRow.append(createTh('', 'col-handle'));
+
+    thead.append(headerRow);
+    table.append(thead);
+
+    // Body
+    const tbody = document.createElement('tbody');
+
+    model.experiences.rows.forEach((row, rowIdx) => {
+      const tr = document.createElement('tr');
+
+      // Apply row background color class if action is set
+      if (row.action && ROW_CSS_MAP[row.action]) {
+        tr.classList.add(ROW_CSS_MAP[row.action]);
+      }
+
+      // Row number / drag handle
+      const handleTd = document.createElement('td');
+      handleTd.className = 'col-handle';
+      handleTd.textContent = rowIdx + 1;
+      handleTd.draggable = true;
+      handleTd.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('text/plain', rowIdx);
+        tr.style.opacity = '0.4';
+      });
+      handleTd.addEventListener('dragend', () => { tr.style.opacity = '1'; });
+      tr.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '2px solid var(--mep-primary)';
+      });
+      tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });
+      tr.addEventListener('drop', (e) => {
+        e.preventDefault();
+        tr.style.borderTop = '';
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        if (fromIdx !== rowIdx) {
+          model.moveRow(fromIdx, rowIdx);
+          render();
+        }
+      });
+      tr.append(handleTd);
+
+      // Action cell
+      tr.append(createActionCell(row, rowIdx, model, tr));
+
+      // Selector cell — textarea with URL link button
+      tr.append(createTextCell(row.selector, (val) => model.updateRow(rowIdx, 'selector', val)));
+
+      // Page Filter cell — plain input
+      tr.append(createInputCell(row.pageFilter, (val) => model.updateRow(rowIdx, 'pageFilter', val)));
+
+      // Experience column cells — textarea with URL link button
+      model.experiences.columns.forEach((col) => {
+        tr.append(createTextCell(
+          row.values[col.name] || '',
+          (val) => model.updateRowValue(rowIdx, col.name, val),
+        ));
+      });
+
+      // Add column spacer
+      const spacerTd = document.createElement('td');
+      spacerTd.style.border = 'none';
+      spacerTd.style.background = 'transparent';
+      tr.append(spacerTd);
+
+      // Delete row button
+      const deleteTd = document.createElement('td');
+      deleteTd.className = 'col-delete';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.textContent = '\u00D7';
+      deleteBtn.title = 'Delete row';
+      deleteBtn.addEventListener('click', () => { model.removeRow(rowIdx); render(); });
+      deleteTd.append(deleteBtn);
+      tr.append(deleteTd);
+
+      tbody.append(tr);
+    });
+
+    table.append(tbody);
+    gridWrapper.append(table);
+    wrap.append(gridWrapper);
+
+    // Add row button
+    const footer = document.createElement('div');
+    footer.className = 'mep-grid-footer';
+    const addRowBtn = document.createElement('button');
+    addRowBtn.className = 'mep-btn';
+    addRowBtn.textContent = '+ Add Row';
+    addRowBtn.addEventListener('click', () => { model.addRow(); render(); });
+    footer.append(addRowBtn);
+    wrap.append(footer);
+  }
+
+  render();
+  container.append(wrap);
+  return { el: wrap, refresh: render };
+}
+
+/**
+ * Creates a <th> with a drag-to-resize handle on its right edge.
+ * Resizing sets the th's own width/minWidth, which drives the column width.
+ */
+function createTh(text, className, resizable = false) {
+  const th = document.createElement('th');
+  th.className = className;
+  th.textContent = text;
+
+  if (resizable) {
+    const handle = document.createElement('span');
+    handle.className = 'mep-col-resize-handle';
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startW = th.offsetWidth;
+
+      function onMove(me) {
+        const newW = Math.max(60, startW + (me.clientX - startX));
+        th.style.width = `${newW}px`;
+        th.style.minWidth = `${newW}px`;
+      }
+      function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      }
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+    th.append(handle);
+  }
+
+  return th;
+}
+
+/**
+ * Action dropdown cell — applies left-border accent to the <td>
+ * and row background class to the parent <tr>.
+ */
+function createActionCell(row, rowIdx, model, tr) {
+  const td = document.createElement('td');
+  td.className = 'action-cell';
+  if (row.action && ACTION_CSS_MAP[row.action]) td.classList.add(ACTION_CSS_MAP[row.action]);
+
+  const select = document.createElement('select');
+  select.className = 'action-select';
+
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  emptyOpt.textContent = '— Select Action —';
+  select.append(emptyOpt);
+
+  ACTIONS.forEach((action) => {
+    const opt = document.createElement('option');
+    opt.value = action;
+    opt.textContent = action;
+    if (action === row.action) opt.selected = true;
+    select.append(opt);
+  });
+
+  select.addEventListener('change', (e) => {
+    model.updateRow(rowIdx, 'action', e.target.value);
+
+    // Update <td> left-border accent
+    Object.values(ACTION_CSS_MAP).forEach((cls) => td.classList.remove(cls));
+    if (e.target.value && ACTION_CSS_MAP[e.target.value]) {
+      td.classList.add(ACTION_CSS_MAP[e.target.value]);
+    }
+
+    // Update <tr> row background
+    Object.values(ROW_CSS_MAP).forEach((cls) => tr.classList.remove(cls));
+    if (e.target.value && ROW_CSS_MAP[e.target.value]) {
+      tr.classList.add(ROW_CSS_MAP[e.target.value]);
+    }
+  });
+
+  td.append(select);
+  return td;
+}
+
+/**
+ * Textarea cell with auto-grow and URL link button.
+ * Used for Selector and Experience columns.
+ */
+function createTextCell(value, onChange) {
+  const td = document.createElement('td');
+  const wrapper = document.createElement('div');
+  wrapper.className = 'cell-wrapper';
+
+  const textarea = document.createElement('textarea');
+  textarea.className = 'cell-input';
+  textarea.rows = 1;
+  textarea.value = value;
+
+  function autoGrow() {
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }
+
+  textarea.addEventListener('input', () => {
+    autoGrow();
+    onChange(textarea.value);
+  });
+
+  wrapper.append(textarea);
+
+  // URL link button — only visible when value is a URL
+  const linkBtn = document.createElement('a');
+  linkBtn.className = 'cell-link-btn';
+  linkBtn.target = '_blank';
+  linkBtn.rel = 'noopener noreferrer';
+  linkBtn.title = 'Open URL';
+  linkBtn.textContent = '↗';
+
+  function updateLinkBtn() {
+    const val = textarea.value.trim();
+    const isUrl = /^https?:\/\//i.test(val);
+    linkBtn.style.display = isUrl ? '' : 'none';
+    if (isUrl) linkBtn.href = val;
+  }
+
+  textarea.addEventListener('input', updateLinkBtn);
+  updateLinkBtn();
+  wrapper.append(linkBtn);
+
+  td.append(wrapper);
+  requestAnimationFrame(autoGrow);
+  return td;
+}
+
+/**
+ * Plain input cell — used for Page Filter.
+ */
+function createInputCell(value, onChange) {
+  const td = document.createElement('td');
+  const input = document.createElement('input');
+  input.className = 'cell-input cell-input-plain';
+  input.type = 'text';
+  input.value = value;
+  input.addEventListener('change', (e) => onChange(e.target.value));
+  td.append(input);
+  return td;
+}
+
+function showAddColumnDialog(model, refreshFn) {
+  const overlay = document.createElement('div');
+  overlay.className = 'mep-dialog-overlay';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'mep-dialog';
+
+  const h3 = document.createElement('h3');
+  h3.textContent = 'Add Experience Column';
+
+  const field = document.createElement('div');
+  field.className = 'mep-field';
+  const label = document.createElement('label');
+  label.className = 'mep-field-label';
+  label.textContent = 'Column Name';
+  const input = document.createElement('input');
+  input.className = 'mep-input';
+  input.type = 'text';
+  input.placeholder = 'e.g., all, target-returning-users';
+  input.autofocus = true;
+  field.append(label, input);
+
+  const actions = document.createElement('div');
+  actions.className = 'mep-dialog-actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'mep-btn';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => overlay.remove());
+
+  const addBtn = document.createElement('button');
+  addBtn.className = 'mep-btn mep-btn-primary';
+  addBtn.textContent = 'Add';
+  addBtn.addEventListener('click', () => {
+    const name = input.value.trim();
+    if (name) {
+      model.addColumn(name);
+      overlay.remove();
+      refreshFn();
+    }
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') addBtn.click();
+    if (e.key === 'Escape') overlay.remove();
+  });
+
+  actions.append(cancelBtn, addBtn);
+  dialog.append(h3, field, actions);
+  overlay.append(dialog);
+  document.body.append(overlay);
+
+  requestAnimationFrame(() => input.focus());
+}

--- a/tools/mep-manifest/src/ui/experiences-tab.js
+++ b/tools/mep-manifest/src/ui/experiences-tab.js
@@ -2,22 +2,30 @@ import { ACTIONS, MANIFEST_TYPES, EXECUTION_ORDERS } from '../data/manifest-mode
 
 // Maps action name → CSS class for the action <td> left-border accent
 const ACTION_CSS_MAP = {
-  insertContentAfter: 'action-insertcontentafter',
-  replaceContent: 'action-replacecontent',
   remove: 'action-remove',
-  insertContentBefore: 'action-insertcontentbefore',
-  replaceFragment: 'action-replacefragment',
+  replace: 'action-replace',
+  insertBefore: 'action-insertbefore',
+  insertAfter: 'action-insertafter',
+  prependToSection: 'action-prependtosection',
   appendToSection: 'action-appendtosection',
+  replacePage: 'action-replacepage',
+  useBlockCode: 'action-useblockcode',
+  insertScript: 'action-insertscript',
+  updateMetadata: 'action-updatemetadata',
 };
 
 // Maps action name → CSS class applied to the entire <tr> for row background
 const ROW_CSS_MAP = {
-  insertContentAfter: 'row-insertcontentafter',
-  replaceContent: 'row-replacecontent',
   remove: 'row-remove',
-  insertContentBefore: 'row-insertcontentbefore',
-  replaceFragment: 'row-replacefragment',
+  replace: 'row-replace',
+  insertBefore: 'row-insertbefore',
+  insertAfter: 'row-insertafter',
+  prependToSection: 'row-prependtosection',
   appendToSection: 'row-appendtosection',
+  replacePage: 'row-replacepage',
+  useBlockCode: 'row-useblockcode',
+  insertScript: 'row-insertscript',
+  updateMetadata: 'row-updatemetadata',
 };
 
 /**

--- a/tools/mep-manifest/src/ui/experiences-tab.js
+++ b/tools/mep-manifest/src/ui/experiences-tab.js
@@ -134,6 +134,12 @@ export function renderExperiencesTab(container, model) {
     // Body
     const tbody = document.createElement('tbody');
 
+    function clearDragIndicators() {
+      tbody.querySelectorAll('tr').forEach((row) => {
+        row.classList.remove('drag-insert-before', 'drag-insert-after');
+      });
+    }
+
     model.experiences.rows.forEach((row, rowIdx) => {
       const tr = document.createElement('tr');
 
@@ -167,21 +173,44 @@ export function renderExperiencesTab(container, model) {
         e.dataTransfer.setData('text/plain', String(rowIdx));
         tr.classList.add('row-dragging');
       });
-      handle.addEventListener('dragend', () => { tr.classList.remove('row-dragging'); });
+
+      handle.addEventListener('dragend', () => {
+        tr.classList.remove('row-dragging');
+        clearDragIndicators();
+      });
+
       tr.addEventListener('dragover', (e) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
-        tr.style.borderTop = '2px solid var(--mep-primary)';
+
+        const rect = tr.getBoundingClientRect();
+        const isBottomHalf = (e.clientY - rect.top) > rect.height / 2;
+
+        clearDragIndicators();
+        tr.classList.add(isBottomHalf ? 'drag-insert-after' : 'drag-insert-before');
       });
-      tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });
+
+      tr.addEventListener('dragleave', (e) => {
+        if (!tr.contains(e.relatedTarget)) {
+          tr.classList.remove('drag-insert-before', 'drag-insert-after');
+        }
+      });
+
       tr.addEventListener('drop', (e) => {
         e.preventDefault();
-        tr.style.borderTop = '';
         const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
-        if (fromIdx !== rowIdx) {
-          model.moveRow(fromIdx, rowIdx);
-          render();
-        }
+        const isAfter = tr.classList.contains('drag-insert-after');
+        clearDragIndicators();
+
+        if (Number.isNaN(fromIdx) || fromIdx === rowIdx) return;
+
+        let toIdx = isAfter ? rowIdx + 1 : rowIdx;
+        // moveRow splices the row out first, which shifts every index
+        // after it down by one — compensate when dragging downward.
+        if (fromIdx < toIdx) toIdx -= 1;
+
+        model.moveRow(fromIdx, toIdx);
+        render();
       });
       tr.append(handleTd);
 

--- a/tools/mep-manifest/src/ui/experiences-tab.js
+++ b/tools/mep-manifest/src/ui/experiences-tab.js
@@ -145,15 +145,32 @@ export function renderExperiencesTab(container, model) {
       // Row number / drag handle
       const handleTd = document.createElement('td');
       handleTd.className = 'col-handle';
-      handleTd.textContent = rowIdx + 1;
-      handleTd.draggable = true;
-      handleTd.addEventListener('dragstart', (e) => {
-        e.dataTransfer.setData('text/plain', rowIdx);
-        tr.style.opacity = '0.4';
+
+      const handle = document.createElement('div');
+      handle.className = 'drag-handle';
+      handle.draggable = true;
+      handle.title = 'Drag to reorder';
+
+      const grip = document.createElement('span');
+      grip.className = 'drag-handle-grip';
+      grip.textContent = '⠿';
+      grip.setAttribute('aria-hidden', 'true');
+
+      const rowNum = document.createElement('span');
+      rowNum.textContent = rowIdx + 1;
+
+      handle.append(grip, rowNum);
+      handleTd.append(handle);
+
+      handle.addEventListener('dragstart', (e) => {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(rowIdx));
+        tr.classList.add('row-dragging');
       });
-      handleTd.addEventListener('dragend', () => { tr.style.opacity = '1'; });
+      handle.addEventListener('dragend', () => { tr.classList.remove('row-dragging'); });
       tr.addEventListener('dragover', (e) => {
         e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
         tr.style.borderTop = '2px solid var(--mep-primary)';
       });
       tr.addEventListener('dragleave', () => { tr.style.borderTop = ''; });

--- a/tools/mep-manifest/src/ui/file-browser.js
+++ b/tools/mep-manifest/src/ui/file-browser.js
@@ -1,0 +1,184 @@
+import { listFiles } from '../data/da-sheet-adapter.js';
+
+/**
+ * Derive extension from an item — uses item.ext if present,
+ * otherwise parses the name/path.
+ */
+function getExt(item) {
+  if (item.ext) return item.ext.toLowerCase();
+  const name = item.name || item.path || '';
+  const dot = name.lastIndexOf('.');
+  return dot !== -1 ? name.slice(dot + 1).toLowerCase() : '';
+}
+
+/**
+ * File browser for navigating DA content and opening MEP manifest JSON files.
+ * - Folders: navigable
+ * - .json files (sheets/manifests): active, openable
+ * - Everything else (DA docs, html): grayed out / inactive
+ */
+export function renderFileBrowser(container, {
+  org, site, startPath = '', onOpen, onNew,
+}) {
+  const wrap = document.createElement('div');
+  wrap.className = 'mep-file-browser';
+  container.append(wrap);
+
+  let currentPath = startPath;
+
+  function getPathSegments() {
+    return currentPath ? currentPath.split('/').filter(Boolean) : [];
+  }
+
+  async function navigate(path) {
+    currentPath = path;
+    await renderBrowser();
+  }
+
+  async function renderBrowser() {
+    wrap.innerHTML = '';
+
+    // ---- Header ----
+    const header = document.createElement('div');
+    header.className = 'mep-file-browser-header';
+
+    const titleArea = document.createElement('div');
+    titleArea.style.cssText = 'display:flex;flex-direction:column;gap:4px;';
+
+    const title = document.createElement('h2');
+    title.textContent = 'MEP Manifest Tool';
+
+    // Breadcrumb
+    const breadcrumb = document.createElement('div');
+    breadcrumb.className = 'mep-breadcrumb';
+
+    const rootCrumb = document.createElement('button');
+    rootCrumb.className = 'mep-crumb';
+    rootCrumb.textContent = site;
+    rootCrumb.addEventListener('click', () => navigate(''));
+    breadcrumb.append(rootCrumb);
+
+    getPathSegments().forEach((seg, idx, segs) => {
+      const sep = document.createElement('span');
+      sep.className = 'mep-crumb-sep';
+      sep.textContent = '/';
+
+      const crumb = document.createElement('button');
+      crumb.className = 'mep-crumb';
+      crumb.textContent = seg;
+      crumb.addEventListener('click', () => {
+        navigate(segs.slice(0, idx + 1).join('/'));
+      });
+      breadcrumb.append(sep, crumb);
+    });
+
+    titleArea.append(title, breadcrumb);
+
+    const newBtn = document.createElement('button');
+    newBtn.className = 'mep-btn mep-btn-primary';
+    newBtn.textContent = '+ New Manifest';
+    newBtn.addEventListener('click', () => onNew(currentPath));
+
+    header.append(titleArea, newBtn);
+    wrap.append(header);
+
+    // ---- Legend ----
+    const legend = document.createElement('div');
+    legend.className = 'mep-file-legend';
+    legend.innerHTML = '<span class="mep-legend-sheet">● Sheet / Manifest</span>'
+      + '<span class="mep-legend-doc">● DA Document (grayed out)</span>';
+    wrap.append(legend);
+
+    // ---- File list ----
+    const listEl = document.createElement('div');
+    listEl.className = 'mep-file-list';
+
+    const loading = document.createElement('div');
+    loading.className = 'mep-empty';
+    loading.innerHTML = '<span class="mep-empty-icon">⏳</span><span>Loading...</span>';
+    listEl.append(loading);
+    wrap.append(listEl);
+
+    try {
+      const items = await listFiles(org, site, currentPath);
+
+      listEl.innerHTML = '';
+
+      if (!items || items.length === 0) {
+        listEl.innerHTML = '<div class="mep-empty"><span class="mep-empty-icon">📂</span><span>No files found</span></div>';
+        return;
+      }
+
+      // Sort: folders first, then alphabetically
+      const sorted = [...items].sort((a, b) => {
+        const aExt = getExt(a);
+        const bExt = getExt(b);
+        const aIsFolder = !aExt;
+        const bIsFolder = !bExt;
+        if (aIsFolder && !bIsFolder) return -1;
+        if (!aIsFolder && bIsFolder) return 1;
+        return (a.name || a.path || '').localeCompare(b.name || b.path || '');
+      });
+
+      sorted.forEach((item) => {
+        const ext = getExt(item);
+        const isFolder = !ext;
+        const isSheet = ext === 'json';
+        const isActive = isFolder || isSheet;
+        const name = item.name || item.path?.split('/').pop() || '';
+
+        const row = document.createElement('div');
+        row.className = [
+          'mep-file-item',
+          isFolder ? 'is-folder' : '',
+          isSheet ? 'is-sheet' : '',
+          !isActive ? 'is-inactive' : '',
+        ].filter(Boolean).join(' ');
+
+        const icon = document.createElement('span');
+        icon.className = 'mep-file-item-icon';
+        // eslint-disable-next-line no-nested-ternary
+        icon.textContent = isFolder ? '📁' : isSheet ? '📊' : '📝';
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'mep-file-item-name';
+        nameEl.textContent = name;
+
+        row.append(icon, nameEl);
+
+        if (!isActive) {
+          const typeLabel = document.createElement('span');
+          typeLabel.className = 'mep-file-type-label';
+          typeLabel.textContent = ext?.toUpperCase() || 'FILE';
+          row.append(typeLabel);
+        }
+
+        if (isFolder) {
+          const chevron = document.createElement('span');
+          chevron.className = 'mep-crumb-sep';
+          chevron.textContent = '›';
+          row.append(chevron);
+          row.addEventListener('click', () => {
+            navigate(currentPath ? `${currentPath}/${name}` : name);
+          });
+        } else if (isSheet) {
+          const openBtn = document.createElement('span');
+          openBtn.className = 'mep-file-open-label';
+          openBtn.textContent = 'Open';
+          row.append(openBtn);
+          row.addEventListener('click', () => {
+            const fullName = (ext && !name.endsWith(`.${ext}`)) ? `${name}.${ext}` : name;
+            onOpen(currentPath ? `${currentPath}/${fullName}` : fullName);
+          });
+        }
+
+        listEl.append(row);
+      });
+    } catch (err) {
+      listEl.innerHTML = `<div class="mep-empty"><span class="mep-empty-icon">⚠️</span><span>${err.message}</span></div>`;
+    }
+  }
+
+  renderBrowser();
+  return wrap;
+}

--- a/tools/mep-manifest/src/ui/file-browser.js
+++ b/tools/mep-manifest/src/ui/file-browser.js
@@ -12,10 +12,29 @@ function getExt(item) {
 }
 
 /**
+ * Format a lastModified value (ISO string or timestamp) into "DD Mon YYYY HH:MM".
+ */
+function formatDate(raw) {
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return '';
+  const day = String(d.getDate()).padStart(2, '0');
+  const mon = d.toLocaleString('en', { month: 'short' });
+  const year = d.getFullYear();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${day} ${mon} ${year} ${hh}:${mm}`;
+}
+
+/**
  * File browser for navigating DA content and opening MEP manifest JSON files.
- * - Folders: navigable
- * - .json files (sheets/manifests): active, openable
- * - Everything else (DA docs, html): grayed out / inactive
+ * Mirrors the native DA file browser UI:
+ *  - Single breadcrumb bar: org > site > path > NEW (pill chips)
+ *  - Inline "new file" creation (no modal) — spaces replaced with hyphens
+ *  - Column headers: NAME | MODIFIED
+ *  - Folders: navigable
+ *  - .json files (sheets/manifests): active, openable
+ *  - Everything else (DA docs, html): grayed out / inactive
  */
 export function renderFileBrowser(container, {
   org, site, startPath = '', onOpen, onNew,
@@ -35,59 +54,129 @@ export function renderFileBrowser(container, {
     await renderBrowser();
   }
 
-  async function renderBrowser() {
-    wrap.innerHTML = '';
+  /** Render the breadcrumb bar in normal mode. */
+  function renderBreadcrumb(header) {
+    header.innerHTML = '';
 
-    // ---- Header ----
-    const header = document.createElement('div');
-    header.className = 'mep-file-browser-header';
+    // org — static label (non-clickable chip)
+    const orgLabel = document.createElement('span');
+    orgLabel.className = 'mep-crumb mep-crumb-static';
+    orgLabel.textContent = org;
+    header.append(orgLabel);
 
-    const titleArea = document.createElement('div');
-    titleArea.style.cssText = 'display:flex;flex-direction:column;gap:4px;';
+    // separator + site (clickable, navigates to root)
+    const sep0 = document.createElement('span');
+    sep0.className = 'mep-crumb-sep';
+    sep0.textContent = '›';
+    const siteCrumb = document.createElement('button');
+    siteCrumb.className = 'mep-crumb';
+    siteCrumb.textContent = site;
+    siteCrumb.addEventListener('click', () => navigate(''));
+    header.append(sep0, siteCrumb);
 
-    const title = document.createElement('h2');
-    title.textContent = 'MEP Manifest Tool';
-
-    // Breadcrumb
-    const breadcrumb = document.createElement('div');
-    breadcrumb.className = 'mep-breadcrumb';
-
-    const rootCrumb = document.createElement('button');
-    rootCrumb.className = 'mep-crumb';
-    rootCrumb.textContent = site;
-    rootCrumb.addEventListener('click', () => navigate(''));
-    breadcrumb.append(rootCrumb);
-
+    // path segment chips
     getPathSegments().forEach((seg, idx, segs) => {
       const sep = document.createElement('span');
       sep.className = 'mep-crumb-sep';
-      sep.textContent = '/';
-
+      sep.textContent = '›';
       const crumb = document.createElement('button');
       crumb.className = 'mep-crumb';
       crumb.textContent = seg;
       crumb.addEventListener('click', () => {
         navigate(segs.slice(0, idx + 1).join('/'));
       });
-      breadcrumb.append(sep, crumb);
+      header.append(sep, crumb);
     });
 
-    titleArea.append(title, breadcrumb);
-
+    // NEW pill button
+    const newSep = document.createElement('span');
+    newSep.className = 'mep-crumb-sep';
+    newSep.textContent = '›';
     const newBtn = document.createElement('button');
-    newBtn.className = 'mep-btn mep-btn-primary';
-    newBtn.textContent = '+ New Manifest';
-    newBtn.addEventListener('click', () => onNew(currentPath));
+    newBtn.className = 'mep-fb-new-btn';
+    newBtn.textContent = 'NEW';
+    newBtn.addEventListener('click', () => renderNewMode(header));
+    header.append(newSep, newBtn);
+  }
 
-    header.append(titleArea, newBtn);
+  /** Replace NEW button with inline input + Create sheet / Cancel. */
+  function renderNewMode(header) {
+    // Remove last sep + NEW button
+    header.lastElementChild.remove();
+    header.lastElementChild.remove();
+
+    const sep = document.createElement('span');
+    sep.className = 'mep-crumb-sep';
+    sep.textContent = '›';
+
+    const input = document.createElement('input');
+    input.className = 'mep-fb-new-input';
+    input.type = 'text';
+    input.placeholder = 'new-manifest';
+
+    const createBtn = document.createElement('button');
+    createBtn.className = 'mep-btn mep-btn-primary mep-fb-new-create';
+    createBtn.textContent = 'Create sheet';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'mep-btn mep-fb-new-cancel';
+    cancelBtn.textContent = 'Cancel';
+
+    function doCreate() {
+      const name = input.value.trim().replace(/\.json$/i, '');
+      if (!name || name.includes('/')) {
+        input.classList.add('mep-fb-input-error');
+        input.focus();
+        return;
+      }
+      const filePath = currentPath ? `${currentPath}/${name}.json` : `${name}.json`;
+      renderBreadcrumb(header);
+      onNew(filePath);
+    }
+
+    function doCancel() {
+      renderBreadcrumb(header);
+    }
+
+    // Replace spaces with hyphens as the user types
+    input.addEventListener('input', () => {
+      const { selectionStart } = input;
+      const replaced = input.value.replace(/ /g, '-');
+      if (replaced !== input.value) {
+        input.value = replaced;
+        input.setSelectionRange(selectionStart, selectionStart);
+      }
+    });
+
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') doCreate();
+      if (e.key === 'Escape') doCancel();
+    });
+
+    createBtn.addEventListener('click', doCreate);
+    cancelBtn.addEventListener('click', doCancel);
+
+    header.append(sep, input, createBtn, cancelBtn);
+    requestAnimationFrame(() => input.focus());
+  }
+
+  async function renderBrowser() {
+    wrap.innerHTML = '';
+
+    // ---- Breadcrumb header ----
+    const header = document.createElement('div');
+    header.className = 'mep-file-browser-header';
+    renderBreadcrumb(header);
     wrap.append(header);
 
-    // ---- Legend ----
-    const legend = document.createElement('div');
-    legend.className = 'mep-file-legend';
-    legend.innerHTML = '<span class="mep-legend-sheet">● Sheet / Manifest</span>'
-      + '<span class="mep-legend-doc">● DA Document (grayed out)</span>';
-    wrap.append(legend);
+    // ---- Column header row ----
+    const colHeader = document.createElement('div');
+    colHeader.className = 'mep-file-col-header';
+    colHeader.innerHTML = '<span class="mep-file-col-check"></span>'
+      + '<span class="mep-file-col-filter" title="Filter">&#9663;</span>'
+      + '<span class="mep-file-col-name">NAME</span>'
+      + '<span class="mep-file-col-modified">MODIFIED</span>';
+    wrap.append(colHeader);
 
     // ---- File list ----
     const listEl = document.createElement('div');
@@ -135,6 +224,10 @@ export function renderFileBrowser(container, {
           !isActive ? 'is-inactive' : '',
         ].filter(Boolean).join(' ');
 
+        // Visual checkbox (mirrors DA)
+        const chk = document.createElement('span');
+        chk.className = 'mep-file-item-check';
+
         const icon = document.createElement('span');
         icon.className = 'mep-file-item-icon';
         // eslint-disable-next-line no-nested-ternary
@@ -144,18 +237,15 @@ export function renderFileBrowser(container, {
         nameEl.className = 'mep-file-item-name';
         nameEl.textContent = name;
 
-        row.append(icon, nameEl);
+        const modEl = document.createElement('span');
+        modEl.className = 'mep-file-modified';
+        modEl.textContent = formatDate(item.lastModified || item.modified || item.lastmodified);
 
-        if (!isActive) {
-          const typeLabel = document.createElement('span');
-          typeLabel.className = 'mep-file-type-label';
-          typeLabel.textContent = ext?.toUpperCase() || 'FILE';
-          row.append(typeLabel);
-        }
+        row.append(chk, icon, nameEl, modEl);
 
         if (isFolder) {
           const chevron = document.createElement('span');
-          chevron.className = 'mep-crumb-sep';
+          chevron.className = 'mep-file-item-chevron';
           chevron.textContent = '›';
           row.append(chevron);
           row.addEventListener('click', () => {

--- a/tools/mep-manifest/src/ui/info-tab.js
+++ b/tools/mep-manifest/src/ui/info-tab.js
@@ -1,0 +1,84 @@
+import { MANIFEST_TYPES, EXECUTION_ORDERS } from '../data/manifest-model.js';
+
+/**
+ * Renders the Info tab with Manifest Type, Execution Order, Override Name.
+ */
+export function renderInfoTab(container, model) {
+  const wrap = document.createElement('div');
+  wrap.className = 'mep-tab-content';
+  wrap.id = 'tab-info';
+  wrap.style.display = 'none';
+
+  const form = document.createElement('div');
+  form.className = 'mep-info-form';
+
+  // Manifest Type
+  form.append(createSelectField(
+    'Manifest Type',
+    MANIFEST_TYPES,
+    model.info.type,
+    (val) => model.setInfo('type', val),
+  ));
+
+  // Execution Order
+  form.append(createSelectField(
+    'Execution Order',
+    EXECUTION_ORDERS,
+    model.info.executionOrder,
+    (val) => model.setInfo('executionOrder', val),
+  ));
+
+  // Override Name
+  form.append(createTextField(
+    'Override Name',
+    model.info.overrideName,
+    (val) => model.setInfo('overrideName', val),
+    'Optional — used for analytics override',
+  ));
+
+  wrap.append(form);
+  container.append(wrap);
+  return wrap;
+}
+
+function createSelectField(label, options, value, onChange) {
+  const field = document.createElement('div');
+  field.className = 'mep-field';
+
+  const lbl = document.createElement('label');
+  lbl.className = 'mep-field-label';
+  lbl.textContent = label;
+
+  const select = document.createElement('select');
+  select.className = 'mep-select';
+  options.forEach((opt) => {
+    const option = document.createElement('option');
+    option.value = opt;
+    option.textContent = opt.charAt(0).toUpperCase() + opt.slice(1);
+    if (opt === value) option.selected = true;
+    select.append(option);
+  });
+  select.addEventListener('change', (e) => onChange(e.target.value));
+
+  field.append(lbl, select);
+  return field;
+}
+
+function createTextField(label, value, onChange, placeholder = '') {
+  const field = document.createElement('div');
+  field.className = 'mep-field';
+
+  const lbl = document.createElement('label');
+  lbl.className = 'mep-field-label';
+  lbl.textContent = label;
+
+  const input = document.createElement('input');
+  input.className = 'mep-input';
+  input.type = 'text';
+  input.value = value;
+  input.placeholder = placeholder;
+  input.addEventListener('input', (e) => onChange(e.target.value));
+
+  field.append(lbl, input);
+  return field;
+}

--- a/tools/mep-manifest/src/ui/placeholders-tab.js
+++ b/tools/mep-manifest/src/ui/placeholders-tab.js
@@ -1,0 +1,64 @@
+/**
+ * Renders the Placeholders tab with key/value rows.
+ */
+export function renderPlaceholdersTab(container, model) {
+  const wrap = document.createElement('div');
+  wrap.className = 'mep-tab-content';
+  wrap.id = 'tab-placeholders';
+  wrap.style.display = 'none';
+
+  function render() {
+    wrap.innerHTML = '';
+    const list = document.createElement('div');
+    list.className = 'mep-placeholders';
+
+    model.placeholders.forEach((ph, idx) => {
+      const row = document.createElement('div');
+      row.className = 'mep-placeholder-row';
+
+      const keyInput = document.createElement('input');
+      keyInput.className = 'mep-input';
+      keyInput.type = 'text';
+      keyInput.placeholder = 'Key';
+      keyInput.value = ph.key;
+      keyInput.addEventListener('change', (e) => {
+        model.updatePlaceholder(idx, 'key', e.target.value);
+      });
+
+      const valInput = document.createElement('input');
+      valInput.className = 'mep-input';
+      valInput.type = 'text';
+      valInput.placeholder = 'Value';
+      valInput.value = ph.value;
+      valInput.addEventListener('change', (e) => {
+        model.updatePlaceholder(idx, 'value', e.target.value);
+      });
+
+      const delBtn = document.createElement('button');
+      delBtn.className = 'mep-btn mep-btn-icon';
+      delBtn.textContent = '\u00D7';
+      delBtn.title = 'Remove';
+      delBtn.addEventListener('click', () => {
+        model.removePlaceholder(idx);
+        render();
+      });
+
+      row.append(keyInput, valInput, delBtn);
+      list.append(row);
+    });
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'mep-btn';
+    addBtn.textContent = '+ Add Placeholder';
+    addBtn.addEventListener('click', () => {
+      model.addPlaceholder();
+      render();
+    });
+
+    wrap.append(list, addBtn);
+  }
+
+  render();
+  container.append(wrap);
+  return { el: wrap, refresh: render };
+}

--- a/tools/mep-manifest/src/ui/status-bar.js
+++ b/tools/mep-manifest/src/ui/status-bar.js
@@ -1,0 +1,21 @@
+/**
+ * Renders a status bar at the bottom of the app.
+ */
+export function renderStatusBar(container, model) {
+  const bar = document.createElement('div');
+  bar.className = 'mep-status';
+  bar.textContent = 'Ready';
+
+  model.onChange(() => {
+    bar.textContent = model.dirty ? 'Unsaved changes' : 'Saved';
+    bar.className = `mep-status ${model.dirty ? 'mep-status-unsaved' : 'mep-status-saved'}`;
+  });
+
+  container.append(bar);
+  return bar;
+}
+
+export function setStatus(bar, text, type = '') {
+  bar.textContent = text;
+  bar.className = `mep-status ${type ? `mep-status-${type}` : ''}`;
+}

--- a/tools/mep-manifest/src/ui/tab-nav.js
+++ b/tools/mep-manifest/src/ui/tab-nav.js
@@ -1,0 +1,32 @@
+/**
+ * Renders tab navigation: Info | Placeholders | Experiences
+ */
+
+const TABS = [
+  { id: 'experiences', label: 'Experiences' },
+  { id: 'placeholders', label: 'Placeholders' },
+];
+
+export function renderTabNav(container, onTabChange) {
+  const nav = document.createElement('div');
+  nav.className = 'mep-tabs';
+
+  TABS.forEach((tab) => {
+    const btn = document.createElement('button');
+    btn.className = 'mep-tab';
+    btn.dataset.tab = tab.id;
+    btn.textContent = tab.label;
+    btn.addEventListener('click', () => {
+      nav.querySelectorAll('.mep-tab').forEach((t) => t.classList.remove('active'));
+      btn.classList.add('active');
+      onTabChange(tab.id);
+    });
+    nav.append(btn);
+  });
+
+  // Default to experiences tab
+  nav.querySelector('[data-tab="experiences"]').classList.add('active');
+
+  container.append(nav);
+  return nav;
+}

--- a/tools/mep-manifest/src/ui/toast.js
+++ b/tools/mep-manifest/src/ui/toast.js
@@ -1,0 +1,91 @@
+/**
+ * Shows a result toast notification anchored below the toolbar.
+ * Auto-dismisses after 8 seconds. Call dismiss() to remove early.
+ *
+ * @param {'success'|'error'} type
+ * @param {string} title  — headline text
+ * @param {string} [url]  — optional URL to show with Open + Copy buttons
+ * @param {string} [detail] — optional secondary line (error message etc.)
+ */
+export function showToast(type, title, { url, detail } = {}) {
+  // Remove any existing toast
+  document.querySelector('.mep-toast')?.remove();
+
+  const toast = document.createElement('div');
+  toast.className = `mep-toast mep-toast-${type}`;
+
+  // Header row: icon + title + close button
+  const head = document.createElement('div');
+  head.className = 'mep-toast-head';
+
+  const icon = document.createElement('span');
+  icon.className = 'mep-toast-icon';
+  icon.textContent = type === 'success' ? '✓' : '✕';
+
+  const titleEl = document.createElement('span');
+  titleEl.className = 'mep-toast-title';
+  titleEl.textContent = title;
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'mep-toast-close';
+  closeBtn.textContent = '×';
+  closeBtn.addEventListener('click', () => toast.remove());
+
+  head.append(icon, titleEl, closeBtn);
+  toast.append(head);
+
+  // URL row
+  if (url) {
+    const urlRow = document.createElement('div');
+    urlRow.className = 'mep-toast-url-row';
+
+    const urlText = document.createElement('span');
+    urlText.className = 'mep-toast-url';
+    urlText.textContent = url;
+    urlText.title = url;
+
+    urlRow.append(urlText);
+    toast.append(urlRow);
+
+    // Action buttons
+    const actions = document.createElement('div');
+    actions.className = 'mep-toast-actions';
+
+    const openBtn = document.createElement('a');
+    openBtn.className = 'mep-btn mep-btn-primary mep-toast-btn';
+    openBtn.textContent = type === 'success' && title.toLowerCase().includes('publish') ? 'Open Live URL' : 'Open Preview';
+    openBtn.href = url;
+    openBtn.target = '_blank';
+    openBtn.rel = 'noopener';
+
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'mep-btn mep-toast-btn';
+    copyBtn.textContent = 'Copy URL';
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(url).then(() => {
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy URL'; }, 2000);
+      });
+    });
+
+    actions.append(openBtn, copyBtn);
+    toast.append(actions);
+  }
+
+  // Detail / error message
+  if (detail) {
+    const detailEl = document.createElement('div');
+    detailEl.className = 'mep-toast-detail';
+    detailEl.textContent = detail;
+    toast.append(detailEl);
+  }
+
+  document.body.append(toast);
+
+  // Auto-dismiss after 8s for success, 12s for errors
+  const ttl = type === 'success' ? 8000 : 12000;
+  const timer = setTimeout(() => toast.remove(), ttl);
+  closeBtn.addEventListener('click', () => clearTimeout(timer));
+
+  return toast;
+}

--- a/tools/mep-manifest/src/ui/toolbar.js
+++ b/tools/mep-manifest/src/ui/toolbar.js
@@ -1,0 +1,71 @@
+/**
+ * Renders the top toolbar with Save, Preview, Publish, Close buttons.
+ * Returns { toolbar, previewBtn, publishBtn } so callers can toggle loading state.
+ */
+export function renderToolbar(container, {
+  onSave, onPreview, onPublish, onNew, onClose, model,
+}) {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'mep-toolbar';
+
+  const left = document.createElement('div');
+  left.className = 'mep-toolbar-left';
+
+  if (onClose) {
+    const backBtn = createButton('← Files', 'mep-btn', onClose);
+    left.append(backBtn);
+  }
+
+  const title = document.createElement('span');
+  title.className = 'mep-toolbar-title';
+  title.textContent = model.filePath || 'New Manifest';
+  left.append(title);
+
+  const right = document.createElement('div');
+  right.className = 'mep-toolbar-right';
+
+  const newBtn = createButton('+ New', 'mep-btn', onNew);
+  const saveBtn = createButton('Save', 'mep-btn', onSave);
+  const previewBtn = createButton('Preview', 'mep-btn', onPreview);
+  const publishBtn = createButton('Publish', 'mep-btn mep-btn-primary', onPublish);
+
+  right.append(newBtn, saveBtn, previewBtn, publishBtn);
+  toolbar.append(left, right);
+  container.append(toolbar);
+
+  model.onChange(() => {
+    const path = model.filePath || 'New Manifest';
+    title.textContent = model.dirty ? `${path} *` : path;
+  });
+
+  return { toolbar, previewBtn, publishBtn };
+}
+
+/**
+ * Toggle a button between normal and loading state.
+ * @param {HTMLButtonElement} btn
+ * @param {boolean} loading
+ * @param {string} [loadingText]
+ */
+export function setButtonLoading(btn, loading, loadingText = '') {
+  // eslint-disable-next-line no-param-reassign
+  btn.disabled = loading;
+  if (loading) {
+    btn.dataset.origText = btn.textContent;
+    // eslint-disable-next-line no-param-reassign
+    btn.textContent = loadingText || btn.textContent;
+    btn.classList.add('mep-btn-loading');
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    btn.textContent = btn.dataset.origText || btn.textContent;
+    btn.classList.remove('mep-btn-loading');
+  }
+}
+
+function createButton(text, className, onClick) {
+  const btn = document.createElement('button');
+  btn.className = className;
+  btn.textContent = text;
+  btn.addEventListener('click', onClick);
+  return btn;
+}


### PR DESCRIPTION
## Summary
- Makes the Experiences grid's existing row drag-and-drop reordering discoverable: replaces the bare row-number handle with a visible grip icon (⠿) and a "Drag to reorder" tooltip.
- Adds an unambiguous before/after insertion-line indicator that snaps above or below the hovered row based on cursor position, with corrected drop-index math so the row lands exactly where the indicator shows.
- Replaces inline-style dragging feedback with CSS classes (`row-dragging`, `drag-insert-before`/`drag-insert-after`) and ensures all transient drag state is cleaned up on `dragend`/`dragleave`/`drop`, including drops outside the grid.
- No changes to the data model or DA save/preview/publish flow — row order was already array position and already round-trips correctly through `toSheet()`.

Design spec: `docs/superpowers/specs/2026-07-23-row-reorder-polish-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-23-row-reorder-polish.md`

## Test plan
- [x] `npx eslint tools/mep-manifest/src/ui/experiences-tab.js` — no new errors (12 pre-existing, unrelated to this change)
- [x] `npx stylelint tools/mep-manifest/mep-manifest.css` — no new errors (20 pre-existing, unrelated to this change)
- [x] Manual browser verification: grip handle renders, `row-dragging`/opacity toggles correctly on dragstart/dragend
- [x] Manual browser verification: before/after insertion indicator shows correct box-shadow line based on cursor position within the hovered row
- [x] Manual browser verification: drop index math confirmed correct for drag-up, drag-down, drop-at-start, and drop-at-end cases
- [x] Manual browser verification: dragging out of the grid and releasing leaves no stale highlight/opacity